### PR TITLE
Replace nil with null

### DIFF
--- a/build/Command/CreateBundleCommand.php
+++ b/build/Command/CreateBundleCommand.php
@@ -7,7 +7,6 @@ use Illuminate\Console\Command;
 use Illuminate\View\Factory;
 use Symfony\Component\Process\ProcessBuilder;
 use const phln\collection\last;
-use const phln\fn\nil;
 use const phln\fn\T;
 use const phln\object\keys;
 use const phln\relation\𝑓equals;
@@ -183,7 +182,7 @@ class CreateBundleCommand extends Command
     private function getParametersDefinition(array $parameters)
     {
         $exportDefaultValue = cond([
-            [partial(𝑓equals, [nil]), always('nil')],
+            // [partial(𝑓equals, [nil]), always('nil')],
             [equals([]), always('[]')],
             [T, function ($value) {
                 return var_export($value, true);

--- a/build/Command/CreateBundleCommand.php
+++ b/build/Command/CreateBundleCommand.php
@@ -181,7 +181,6 @@ class CreateBundleCommand extends Command
     private function getParametersDefinition(array $parameters)
     {
         $exportDefaultValue = cond([
-            // [partial(𝑓equals, [nil]), always('nil')],
             [equals([]), always('[]')],
             [T, function ($value) {
                 return var_export($value, true);

--- a/build/Command/CreateBundleCommand.php
+++ b/build/Command/CreateBundleCommand.php
@@ -174,9 +174,8 @@ class CreateBundleCommand extends Command
 
         $mappedParams = map($mapParameters, $parameters);
         $definition = $this->getParametersDefinition($mappedParams);
-        $invoke = $this->getParametersInvokeDefinition($mappedParams);
 
-        return compact('definition', 'invoke');
+        return compact('definition');
     }
 
     private function getParametersDefinition(array $parameters)
@@ -207,20 +206,6 @@ class CreateBundleCommand extends Command
 
         return pipe([
             map($toSrc),
-            join(', '),
-        ])($parameters);
-    }
-
-    private function getParametersInvokeDefinition(array $parameters)
-    {
-        return pipe([
-            map(function ($param) {
-                return sprintf(
-                    '%s$%s',
-                    $param['variadic'] ? '...' : '',
-                    $param['name']
-                );
-            }),
             join(', '),
         ])($parameters);
     }

--- a/build/template/function.blade.php
+++ b/build/template/function.blade.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace phln\{{$ns}};
 
 use function phln\fn\curryN;
-use const phln\fn\nil;
 
 const {{$name}} = '\\phln\\{{$ns}}\\{{$name}}';
 const 𝑓{{$name}} = '\\phln\\{{$ns}}\\𝑓{{$name}}';

--- a/build/template/phln-class.blade.php
+++ b/build/template/phln-class.blade.php
@@ -17,7 +17,7 @@ class Phln
 {!! $item['doc'] !!}
     public static function {{ $item['name'] }}({!! $item['parameters']['definition'] !!}){{ $item['returnType'] }}
     {
-        return \{{ $item['fqn'] }}({{ $item['parameters']['invoke'] }});
+        return \{{ $item['fqn'] }}(...func_get_args());
     }
 
 @endforeach

--- a/build/template/phln-class.blade.php
+++ b/build/template/phln-class.blade.php
@@ -7,8 +7,6 @@ declare(strict_types=1);
 
 namespace phln;
 
-use const phln\fn\nil;
-
 class Phln
 {
 @foreach($constants as $item)

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -533,7 +533,7 @@ When applied, `g` returns the result of applying `f` to the arguments provided i
 Special placeholder value `P::__` may be used to specify "gaps", allowing partial application of any combination of arguments, regardless of their positions.
 
 ```php
-$subtractFive = P::partial(P::subtract, P::__, 5);
+$subtractFive = P::partial(P::subtract, [P::__, 5]);
 $subtractFive(10); // 5
 ```
 

--- a/src/Phln.php
+++ b/src/Phln.php
@@ -114,16 +114,16 @@ class Phln
      *
      * @phlnSignature (a -> Boolean) -> [a] -> Boolean
      * @phlnCategory collection
-     * @param string $predicate
-     * @param string $list
+     * @param callable $predicate
+     * @param array $list
      * @return \Closure|bool
      * @example
      *      $onlyTwos = P::all(P::equals(2));
      *      $onlyTwos([1, 2, 2]); // false
      */
-    public static function all($predicate = NULL, $list = NULL)
+    public static function all(callable $predicate = NULL, array $list = [])
     {
-        return \phln\collection\all($predicate, $list);
+        return \phln\collection\all(...func_get_args());
     }
 
     /**
@@ -131,16 +131,16 @@ class Phln
      *
      * @phlnSignature (a -> Boolean) -> [a] -> Boolean
      * @phlnCategory collection
-     * @param string $predicate
-     * @param string $list
+     * @param callable $predicate
+     * @param array $list
      * @return \Closure|bool
      * @example
      *      $hasTwos = P::any(P::equals(2));
      *      $hasTwos([1, 2, 3, 4]); // true
      */
-    public static function any($predicate = NULL, $list = NULL)
+    public static function any(callable $predicate = NULL, array $list = [])
     {
-        return \phln\collection\any($predicate, $list);
+        return \phln\collection\any(...func_get_args());
     }
 
     /**
@@ -150,7 +150,7 @@ class Phln
      * @phlnSignature String -> String -> String
      * @phlnCategory collection
      * @param mixed $value
-     * @param string|array $collection
+     * @param array|string $collection
      * @return \Closure|string|array
      * @example
      *      P::append(3, [1, 2]); // [1, 2, 3]
@@ -159,7 +159,7 @@ class Phln
      */
     public static function append($value = NULL, $collection = NULL)
     {
-        return \phln\collection\append($value, $collection);
+        return \phln\collection\append(...func_get_args());
     }
 
     /**
@@ -169,16 +169,16 @@ class Phln
      * @phlnSignature Number -> [a] -> [[a]]
      * @phlnSignature Number -> String -> [String]
      * @phlnCategory collection
-     * @param string|integer $size
-     * @param string|array $collection
+     * @param integer $size
+     * @param array|string $collection
      * @return \Closure|array
      * @example
      *      P::chunk(2, [1, 2, 3, 4]); // [[1, 2], [3, 4]]
      *      P::chunk(2, 'hello'); // ['he', 'll', 'o']
      */
-    public static function chunk($size = NULL, $collection = NULL)
+    public static function chunk(int $size = 0, $collection = NULL)
     {
-        return \phln\collection\chunk($size, $collection);
+        return \phln\collection\chunk(...func_get_args());
     }
 
     /**
@@ -191,7 +191,7 @@ class Phln
      */
     public static function collapse(array $list): array
     {
-        return \phln\collection\collapse($list);
+        return \phln\collection\collapse(...func_get_args());
     }
 
     /**
@@ -212,7 +212,7 @@ class Phln
      */
     public static function concat($a = NULL, $b = NULL)
     {
-        return \phln\collection\concat($a, $b);
+        return \phln\collection\concat(...func_get_args());
     }
 
     /**
@@ -223,7 +223,7 @@ class Phln
      * @phlnSignature String -> String -> Boolean
      * @phlnCategory collection
      * @param mixed $value
-     * @param string|array $collection
+     * @param array|string $collection
      * @return \Closure|bool
      * @example
      *      P::contains(1, [1, 2, 3]); // true
@@ -231,7 +231,7 @@ class Phln
      */
     public static function contains($value = NULL, $collection = NULL)
     {
-        return \phln\collection\contains($value, $collection);
+        return \phln\collection\contains(...func_get_args());
     }
 
     /**
@@ -239,15 +239,15 @@ class Phln
      *
      * @phlnSignature (a -> Boolean) -> [a] -> Boolean
      * @phlnCategory collection
-     * @param string $predicate
-     * @param string $list
+     * @param callable $predicate
+     * @param array $list
      * @return \Closure|mixed
      * @example
      *      P::filter(equals(1), [1, 2, 3]); // [1]
      */
-    public static function filter($predicate = NULL, $list = NULL)
+    public static function filter(callable $predicate = NULL, array $list = [])
     {
-        return \phln\collection\filter($predicate, $list);
+        return \phln\collection\filter(...func_get_args());
     }
 
     /**
@@ -256,16 +256,16 @@ class Phln
      *
      * @phlnSignature (a -> Boolean) -> [a] -> a
      * @phlnCategory collection
-     * @param string $predicate
-     * @param string $list
+     * @param callable $predicate
+     * @param array $list
      * @return \Closure|mixed
      * @example
      *      $xs = [['a' => 1], ['a' => 2], ['a' => 3]];
      *      P::find(equals(['a' => 1]), $xs); // ['a' => 1]
      */
-    public static function find($predicate = NULL, $list = NULL)
+    public static function find(callable $predicate = NULL, array $list = [])
     {
-        return \phln\collection\find($predicate, $list);
+        return \phln\collection\find(...func_get_args());
     }
 
     /**
@@ -273,8 +273,8 @@ class Phln
      *
      * @phlnSignature (a -> b) -> [a] -> [b]
      * @phlnCategory collection
-     * @param string $mapper
-     * @param string $list
+     * @param callable $mapper
+     * @param array $list
      * @return \Closure|mixed
      * @example
      *      $duplicateElements = P::flatMap(function ($i) {
@@ -283,9 +283,9 @@ class Phln
      *
      *      $duplicateElements([1, 2]); // [1, 1, 2, 2]
      */
-    public static function flatMap($mapper = NULL, $list = NULL)
+    public static function flatMap(callable $mapper = NULL, array $list = [])
     {
-        return \phln\collection\flatMap($mapper, $list);
+        return \phln\collection\flatMap(...func_get_args());
     }
 
     /**
@@ -304,7 +304,7 @@ class Phln
      */
     public static function head($collection)
     {
-        return \phln\collection\head($collection);
+        return \phln\collection\head(...func_get_args());
     }
 
     /**
@@ -328,7 +328,7 @@ class Phln
      */
     public static function init($collection)
     {
-        return \phln\collection\init($collection);
+        return \phln\collection\init(...func_get_args());
     }
 
     /**
@@ -337,15 +337,15 @@ class Phln
      * @phlnSignature String -> [a] -> String
      * @phlnCategory collection
      * @param string $separator
-     * @param string $list
+     * @param array $list
      * @return \Closure|mixed
      * @example
      *      $spacer = P::join(' ');
      *      $spacer([1, 2, 3]); // '1 2 3'
      */
-    public static function join($separator = NULL, $list = NULL)
+    public static function join(string $separator = '', array $list = [])
     {
-        return \phln\collection\join($separator, $list);
+        return \phln\collection\join(...func_get_args());
     }
 
     /**
@@ -364,7 +364,7 @@ class Phln
      */
     public static function last($list)
     {
-        return \phln\collection\last($list);
+        return \phln\collection\last(...func_get_args());
     }
 
     /**
@@ -380,7 +380,7 @@ class Phln
      */
     public static function length($collection): int
     {
-        return \phln\collection\length($collection);
+        return \phln\collection\length(...func_get_args());
     }
 
     /**
@@ -388,13 +388,13 @@ class Phln
      *
      * @phlnSignature (a -> b) -> [a] -> [b]
      * @phlnCategory collection
-     * @param string|callable $fn
-     * @param string|array $list
+     * @param callable $fn
+     * @param array $list
      * @return \Closure|array
      */
-    public static function map($fn = NULL, $list = NULL)
+    public static function map(callable $fn = NULL, array $list = [])
     {
-        return \phln\collection\map($fn, $list);
+        return \phln\collection\map(...func_get_args());
     }
 
     /**
@@ -404,13 +404,13 @@ class Phln
      *
      * @phlnSignature ((a, i) -> b) -> [a] -> [b]
      * @phlnCategory collection
-     * @param string|callable $fn
-     * @param string|array $list
+     * @param callable $fn
+     * @param array $list
      * @return \Closure|array
      */
-    public static function mapIndexed($fn = NULL, $list = NULL)
+    public static function mapIndexed(callable $fn = NULL, array $list = [])
     {
-        return \phln\collection\mapIndexed($fn, $list);
+        return \phln\collection\mapIndexed(...func_get_args());
     }
 
     /**
@@ -418,8 +418,8 @@ class Phln
      *
      * @phlnSignature (a -> Boolean) -> [a] -> Boolean
      * @phlnCategory collection
-     * @param string $predicate
-     * @param string $list
+     * @param callable $predicate
+     * @param array $list
      * @return \Closure|mixed
      * @example
      *      $isEven = function ($i) {
@@ -429,9 +429,9 @@ class Phln
      *      P::none($isEven, [1, 3, 5]); // true
      *      P::none($isEven, [1, 3, 5, 6]); // false
      */
-    public static function none($predicate = NULL, $list = NULL)
+    public static function none(callable $predicate = NULL, array $list = [])
     {
-        return \phln\collection\none($predicate, $list);
+        return \phln\collection\none(...func_get_args());
     }
 
     /**
@@ -440,16 +440,16 @@ class Phln
      *
      * @phlnSignature Number -> [a] -> a | Null
      * @phlnCategory collection
-     * @param string $n
-     * @param string $list
+     * @param integer $n
+     * @param array $list
      * @return \Closure|mixed
      * @example
      *      P::nth(1, [1, 2, 3]); // 2
      *      P::nth(-1, [1, 2, 3]); // 3
      */
-    public static function nth($n = NULL, $list = NULL)
+    public static function nth(int $n = 0, array $list = [])
     {
-        return \phln\collection\nth($n, $list);
+        return \phln\collection\nth(...func_get_args());
     }
 
     /**
@@ -457,16 +457,16 @@ class Phln
      *
      * @phlnSignature k -> [{k: v}] -> v
      * @phlnCategory collection
-     * @param string $key
-     * @param string|array $list
+     * @param string|integer $key
+     * @param array $list
      * @return \Closure|array
      * @example
      *      $list = [['a' => 1], ['a' => 2]];
      *      P::pluck('a', $list); // [1, 2]
      */
-    public static function pluck($key = NULL, $list = NULL)
+    public static function pluck($key = '', array $list = [])
     {
-        return \phln\collection\pluck($key, $list);
+        return \phln\collection\pluck(...func_get_args());
     }
 
     /**
@@ -475,7 +475,7 @@ class Phln
      * @phlnSignature a -> [a] -> [a]
      * @phlnSignature String -> String -> String
      * @phlnCategory collection
-     * @param string $value
+     * @param mixed $value
      * @param string|array $collection
      * @return \Closure|array
      * @example
@@ -485,7 +485,7 @@ class Phln
      */
     public static function prepend($value = NULL, $collection = NULL)
     {
-        return \phln\collection\prepend($value, $collection);
+        return \phln\collection\prepend(...func_get_args());
     }
 
     /**
@@ -493,15 +493,15 @@ class Phln
      *
      * @phlnSignature Integer a => a -> a -> [a]
      * @phlnCategory collection
-     * @param string|int $start
-     * @param string|int $end
+     * @param int $start
+     * @param int $end
      * @return \Closure|array
      * @example
      *      P::range(0, 3); // [0, 1, 2]
      */
-    public static function range($start = NULL, $end = NULL)
+    public static function range(int $start = 0, int $end = 0)
     {
-        return \phln\collection\range($start, $end);
+        return \phln\collection\range(...func_get_args());
     }
 
     /**
@@ -511,17 +511,17 @@ class Phln
      *
      * @phlnSignature ((a, b) -> a) -> a -> [b] -> a
      * @phlnCategory collection
-     * @param string|callable $reducer
+     * @param callable $reducer
      * @param mixed $initialValue
-     * @param string|array $list
+     * @param array $list
      * @return \Closure|mixed
      * @example
      *      P::reduce(P::subtract, 0, [1, 2, 3, 4]);
      *      // ((((0 - 1) - 2) - 3) - 4) => -10
      */
-    public static function reduce($reducer = NULL, $initialValue = NULL, $list = NULL)
+    public static function reduce(callable $reducer = NULL, $initialValue = NULL, array $list = [])
     {
-        return \phln\collection\reduce($reducer, $initialValue, $list);
+        return \phln\collection\reduce(...func_get_args());
     }
 
     /**
@@ -529,8 +529,8 @@ class Phln
      *
      * @phlnSignature (a -> Boolean) -> [a] -> [a]
      * @phlnCategory collection
-     * @param string|callable $predicate
-     * @param string|array $list
+     * @param callable $predicate
+     * @param array $list
      * @return \Closure|array
      * @example
      *      $isOdd = function ($i) {
@@ -538,9 +538,9 @@ class Phln
      *      };
      *      P::reject($isOdd, [1, 2, 3, 4]); // [2, 4]
      */
-    public static function reject($predicate = NULL, $list = NULL)
+    public static function reject(callable $predicate = NULL, array $list = [])
     {
-        return \phln\collection\reject($predicate, $list);
+        return \phln\collection\reject(...func_get_args());
     }
 
     /**
@@ -559,7 +559,7 @@ class Phln
      */
     public static function reverse($collection)
     {
-        return \phln\collection\reverse($collection);
+        return \phln\collection\reverse(...func_get_args());
     }
 
     /**
@@ -568,8 +568,8 @@ class Phln
      * @phlnSignature Integer -> Integer -> [a] -> [a]
      * @phlnSignature Integer -> Integer -> String -> String
      * @phlnCategory collection
-     * @param string|integer $offset
-     * @param string|integer $length
+     * @param integer $offset
+     * @param integer $length
      * @param string|array $collection
      * @return \Closure|array|string
      * @see \array_slice()
@@ -578,9 +578,9 @@ class Phln
      *      $takeTwo = P::slice(0, 2);
      *      $takeTwo([1, 2, 3]); // [1, 2]
      */
-    public static function slice($offset = NULL, $length = NULL, $collection = NULL)
+    public static function slice(int $offset = 0, int $length = 0, $collection = NULL)
     {
-        return \phln\collection\slice($offset, $length, $collection);
+        return \phln\collection\slice(...func_get_args());
     }
 
     /**
@@ -588,8 +588,8 @@ class Phln
      *
      * @phlnSignature ((a, a) -> Number) -> [a] -> [a]
      * @phlnCategory collection
-     * @param string|callable $comparator
-     * @param string|array $list
+     * @param callable $comparator
+     * @param array $list
      * @return \Closure|array
      * @see \usort()
      * @example
@@ -599,9 +599,9 @@ class Phln
      *
      *      P::sort($diff, [3, 2, 1]); // [1, 2, 3]
      */
-    public static function sort($comparator = NULL, $list = NULL)
+    public static function sort(callable $comparator = NULL, array $list = [])
     {
-        return \phln\collection\sort($comparator, $list);
+        return \phln\collection\sort(...func_get_args());
     }
 
     /**
@@ -609,8 +609,8 @@ class Phln
      *
      * @phlnSignature (a -> b) -> [a] -> [a]
      * @phlnCategory collection
-     * @param string|callable $mapper
-     * @param string|array $list
+     * @param callable $mapper
+     * @param array $list
      * @return \Closure|array
      * @see \array_multisort()
      * @example
@@ -621,9 +621,9 @@ class Phln
      *
      *      P::soryBy(P::prop('name'), $people); // [$alice, $bob, $clara]
      */
-    public static function sortBy($mapper = NULL, $list = NULL)
+    public static function sortBy(callable $mapper = NULL, array $list = [])
     {
-        return \phln\collection\sortBy($mapper, $list);
+        return \phln\collection\sortBy(...func_get_args());
     }
 
     /**
@@ -644,7 +644,7 @@ class Phln
      */
     public static function tail($collection)
     {
-        return \phln\collection\tail($collection);
+        return \phln\collection\tail(...func_get_args());
     }
 
     /**
@@ -659,7 +659,7 @@ class Phln
      */
     public static function unique(array $list): array
     {
-        return \phln\collection\unique($list);
+        return \phln\collection\unique(...func_get_args());
     }
 
     /**
@@ -671,7 +671,7 @@ class Phln
      */
     public static function F(): bool
     {
-        return \phln\fn\F();
+        return \phln\fn\F(...func_get_args());
     }
 
     /**
@@ -683,7 +683,7 @@ class Phln
      */
     public static function T(): bool
     {
-        return \phln\fn\T();
+        return \phln\fn\T(...func_get_args());
     }
 
     /**
@@ -700,7 +700,7 @@ class Phln
      */
     public static function always($value): \Closure
     {
-        return \phln\fn\always($value);
+        return \phln\fn\always(...func_get_args());
     }
 
     /**
@@ -708,15 +708,15 @@ class Phln
      *
      * @phlnSignature (*... -> a) -> [*] -> a
      * @phlnCategory function
-     * @param string|callable $fn
-     * @param string|array $arguments
+     * @param callable $fn
+     * @param array $arguments
      * @return \Closure|mixed
      * @example
      *      P::apply(P::sum, [1, 2]); // 3
      */
-    public static function apply($fn = NULL, $arguments = NULL)
+    public static function apply(callable $fn = NULL, array $arguments = [])
     {
-        return \phln\fn\apply($fn, $arguments);
+        return \phln\fn\apply(...func_get_args());
     }
 
     /**
@@ -731,7 +731,7 @@ class Phln
      */
     public static function arity(callable $fn): int
     {
-        return \phln\fn\arity($fn);
+        return \phln\fn\arity(...func_get_args());
     }
 
     /**
@@ -748,7 +748,7 @@ class Phln
      */
     public static function compose(array $fns): \Closure
     {
-        return \phln\fn\compose($fns);
+        return \phln\fn\compose(...func_get_args());
     }
 
     /**
@@ -769,7 +769,7 @@ class Phln
      */
     public static function curry(callable $fn, array $args = [])
     {
-        return \phln\fn\curry($fn, $args);
+        return \phln\fn\curry(...func_get_args());
     }
 
     /**
@@ -791,7 +791,7 @@ class Phln
      */
     public static function curryN(int $n, callable $fn, array $args = [])
     {
-        return \phln\fn\curryN($n, $fn, $args);
+        return \phln\fn\curryN(...func_get_args());
     }
 
     /**
@@ -806,7 +806,7 @@ class Phln
      */
     public static function identity($value)
     {
-        return \phln\fn\identity($value);
+        return \phln\fn\identity(...func_get_args());
     }
 
     /**
@@ -825,7 +825,7 @@ class Phln
      */
     public static function negate(callable $predicate): \Closure
     {
-        return \phln\fn\negate($predicate);
+        return \phln\fn\negate(...func_get_args());
     }
 
     /**
@@ -841,7 +841,7 @@ class Phln
      */
     public static function of($value): array
     {
-        return \phln\fn\of($value);
+        return \phln\fn\of(...func_get_args());
     }
 
     /**
@@ -859,7 +859,7 @@ class Phln
      */
     public static function once(callable $fn): \Closure
     {
-        return \phln\fn\once($fn);
+        return \phln\fn\once(...func_get_args());
     }
 
     /**
@@ -870,16 +870,16 @@ class Phln
      *
      * @phlnSignature ((a, b, c, ..., n) -> x) -> [a, b, c, ...] -> ((d, e, f, ..., n) -> x)
      * @phlnCategory function
-     * @param string|callable $fn
-     * @param string|array ...$args
+     * @param callable $fn
+     * @param array $args
      * @return \Closure
      * @example
-     *      $subtractFive = P::partial(P::subtract, P::__, 5);
+     *      $subtractFive = P::partial(P::subtract, [P::__, 5]);
      *      $subtractFive(10); // 5
      */
-    public static function partial($fn = NULL, $args = NULL): \Closure
+    public static function partial(callable $fn = NULL, array $args = []): \Closure
     {
-        return \phln\fn\partial($fn, $args);
+        return \phln\fn\partial(...func_get_args());
     }
 
     /**
@@ -896,7 +896,7 @@ class Phln
      */
     public static function pipe(array $fns): \Closure
     {
-        return \phln\fn\pipe($fns);
+        return \phln\fn\pipe(...func_get_args());
     }
 
     /**
@@ -914,7 +914,7 @@ class Phln
      */
     public static function swap(callable $f): \Closure
     {
-        return \phln\fn\swap($f);
+        return \phln\fn\swap(...func_get_args());
     }
 
     /**
@@ -929,9 +929,9 @@ class Phln
      *      $dump = P::tap('var_dump');
      *      $dump('foo'); // var_dumps('foo'); returns 'foo'
      */
-    public static function tap($fn = NULL, $value = NULL)
+    public static function tap(callable $fn = NULL, $value = NULL)
     {
-        return \phln\fn\tap($fn, $value);
+        return \phln\fn\tap(...func_get_args());
     }
 
     /**
@@ -950,7 +950,7 @@ class Phln
      */
     public static function throwException(string $exception = 'Exception', array $args = []): \Closure
     {
-        return \phln\fn\throwException($exception, $args);
+        return \phln\fn\throwException(...func_get_args());
     }
 
     /**
@@ -968,9 +968,9 @@ class Phln
      * @example
      *      P::unapply('\\json_encode')(1, 2, 3); // [1,2,3]
      */
-    public static function unapply($fn = NULL, ...$args)
+    public static function unapply(callable $fn = NULL, ...$args)
     {
-        return \phln\fn\unapply($fn, ...$args);
+        return \phln\fn\unapply(...func_get_args());
     }
 
     /**
@@ -990,7 +990,7 @@ class Phln
      */
     public static function allPass(array $predicates): callable
     {
-        return \phln\logic\allPass($predicates);
+        return \phln\logic\allPass(...func_get_args());
     }
 
     /**
@@ -1015,7 +1015,7 @@ class Phln
      */
     public static function both($left = NULL, $right = NULL)
     {
-        return \phln\logic\both($left, $right);
+        return \phln\logic\both(...func_get_args());
     }
 
     /**
@@ -1040,7 +1040,7 @@ class Phln
      */
     public static function cond(array $pairs): \Closure
     {
-        return \phln\logic\cond($pairs);
+        return \phln\logic\cond(...func_get_args());
     }
 
     /**
@@ -1057,7 +1057,7 @@ class Phln
      */
     public static function defaultTo($default = NULL, $value = NULL)
     {
-        return \phln\logic\defaultTo($default, $value);
+        return \phln\logic\defaultTo(...func_get_args());
     }
 
     /**
@@ -1084,7 +1084,7 @@ class Phln
      */
     public static function either($left = NULL, $right = NULL)
     {
-        return \phln\logic\either($left, $right);
+        return \phln\logic\either(...func_get_args());
     }
 
     /**
@@ -1092,9 +1092,9 @@ class Phln
      *
      * @phlnSignature (*... -> Boolean) -> (*... -> *) -> (*... -> *) -> (*... -> *)
      * @phlnCategory logic
-     * @param string|callable $predicate
-     * @param string|callable $onTrue
-     * @param string|callable $onFalse
+     * @param callable $predicate
+     * @param callable $onTrue
+     * @param callable $onFalse
      * @return \Closure
      * @example
      *      $modulo15 = P::swap(P::modulo)(15);
@@ -1107,9 +1107,9 @@ class Phln
      *      $fizzbuzz(15); // 'fizzbuzz'
      *      $fizzbuzz(1); // 1
      */
-    public static function ifElse($predicate = NULL, $onTrue = NULL, $onFalse = NULL): \Closure
+    public static function ifElse(callable $predicate = NULL, callable $onTrue = NULL, callable $onFalse = NULL): \Closure
     {
-        return \phln\logic\ifElse($predicate, $onTrue, $onFalse);
+        return \phln\logic\ifElse(...func_get_args());
     }
 
     /**
@@ -1132,7 +1132,7 @@ class Phln
      */
     public static function isEmpty($value): bool
     {
-        return \phln\logic\isEmpty($value);
+        return \phln\logic\isEmpty(...func_get_args());
     }
 
     /**
@@ -1148,7 +1148,7 @@ class Phln
      */
     public static function not($value): bool
     {
-        return \phln\logic\not($value);
+        return \phln\logic\not(...func_get_args());
     }
 
     /**
@@ -1162,7 +1162,7 @@ class Phln
      */
     public static function add($a = NULL, $b = NULL)
     {
-        return \phln\math\add($a, $b);
+        return \phln\math\add(...func_get_args());
     }
 
     /**
@@ -1175,7 +1175,7 @@ class Phln
      */
     public static function dec($number)
     {
-        return \phln\math\dec($number);
+        return \phln\math\dec(...func_get_args());
     }
 
     /**
@@ -1189,7 +1189,7 @@ class Phln
      */
     public static function divide($a = NULL, $b = NULL)
     {
-        return \phln\math\divide($a, $b);
+        return \phln\math\divide(...func_get_args());
     }
 
     /**
@@ -1202,7 +1202,7 @@ class Phln
      */
     public static function inc($number)
     {
-        return \phln\math\inc($number);
+        return \phln\math\inc(...func_get_args());
     }
 
     /**
@@ -1217,7 +1217,7 @@ class Phln
      */
     public static function mean(array $numbers)
     {
-        return \phln\math\mean($numbers);
+        return \phln\math\mean(...func_get_args());
     }
 
     /**
@@ -1233,7 +1233,7 @@ class Phln
      */
     public static function median(array $numbers)
     {
-        return \phln\math\median($numbers);
+        return \phln\math\median(...func_get_args());
     }
 
     /**
@@ -1249,7 +1249,7 @@ class Phln
      */
     public static function modulo($a = NULL, $b = NULL)
     {
-        return \phln\math\modulo($a, $b);
+        return \phln\math\modulo(...func_get_args());
     }
 
     /**
@@ -1266,7 +1266,7 @@ class Phln
      */
     public static function multiply($a = NULL, $b = NULL)
     {
-        return \phln\math\multiply($a, $b);
+        return \phln\math\multiply(...func_get_args());
     }
 
     /**
@@ -1281,7 +1281,7 @@ class Phln
      */
     public static function product(array $numbers)
     {
-        return \phln\math\product($numbers);
+        return \phln\math\product(...func_get_args());
     }
 
     /**
@@ -1289,8 +1289,8 @@ class Phln
      *
      * @phlnSignature Number a => a -> a -> a
      * @phlnCategory math
-     * @param string $a
-     * @param string $b
+     * @param number $a
+     * @param number $b
      * @return \Closure|mixed
      * @example
      *      $complementaryAngle = P::subtract(90);
@@ -1298,7 +1298,7 @@ class Phln
      */
     public static function subtract($a = NULL, $b = NULL)
     {
-        return \phln\math\subtract($a, $b);
+        return \phln\math\subtract(...func_get_args());
     }
 
     /**
@@ -1313,7 +1313,7 @@ class Phln
      */
     public static function sum(array $numbers)
     {
-        return \phln\math\sum($numbers);
+        return \phln\math\sum(...func_get_args());
     }
 
     /**
@@ -1322,15 +1322,15 @@ class Phln
      * @phlnSignature k -> {k: v} -> {k: v} -> Boolean
      * @phlnCategory object
      * @param string $prop
-     * @param string $a
-     * @param string $b
+     * @param array $a
+     * @param array $b
      * @return \Closure|mixed
      * @example
      *      P::eqProps('name', ['name' => 'Jon'], ['name' => 'Jon']); // true
      */
-    public static function eqProps($prop = NULL, $a = NULL, $b = NULL)
+    public static function eqProps(string $prop = '', array $a = [], array $b = [])
     {
-        return \phln\object\eqProps($prop, $a, $b);
+        return \phln\object\eqProps(...func_get_args());
     }
 
     /**
@@ -1346,7 +1346,7 @@ class Phln
      */
     public static function keys(array $object): array
     {
-        return \phln\object\keys($object);
+        return \phln\object\keys(...func_get_args());
     }
 
     /**
@@ -1354,16 +1354,16 @@ class Phln
      *
      * @phlnSignature {k: v} -> {k: v} -> {k: v}
      * @phlnCategory object
-     * @param string|array $left
-     * @param string|array $right
+     * @param array $left
+     * @param array $right
      * @return \Closure|array
      * @example
      *      $toDefaults = P::partial(P::merge, [P::__, ['x' => 0]);
      *      $toDefaults(['x' => 2, 'y' => 1]); // ['x' => 0, 'y' => 1]
      */
-    public static function merge($left = NULL, $right = NULL)
+    public static function merge(array $left = [], array $right = [])
     {
-        return \phln\object\merge($left, $right);
+        return \phln\object\merge(...func_get_args());
     }
 
     /**
@@ -1371,15 +1371,15 @@ class Phln
      *
      * @phlnSignature [String] -> {String: *} -> {String: *}
      * @phlnCategory object
-     * @param string $omitKeys
-     * @param string $object
+     * @param array $omitKeys
+     * @param array $object
      * @return \Closure|mixed
      * @example
      *      P::omit(['a', 'c'], ['a' => 1, 'b' => 2, 'c' => 3]); // ['b' => 2]
      */
-    public static function omit($omitKeys = NULL, $object = NULL)
+    public static function omit(array $omitKeys = [], array $object = [])
     {
-        return \phln\object\omit($omitKeys, $object);
+        return \phln\object\omit(...func_get_args());
     }
 
     /**
@@ -1388,15 +1388,15 @@ class Phln
      * @phlnSignature String -> {k: v} -> v|Null
      * @phlnCategory object
      * @param string $path
-     * @param string|array $object
+     * @param array $object
      * @return \Closure|mixed
      * @example
      *      P::path('a.b', ['a' => ['b' => 'foo']]); // 'foo'
      *      P::path('a.b.c', ['a' => ['b' => 'foo']]); // null
      */
-    public static function path($path = NULL, $object = NULL)
+    public static function path(string $path = '', array $object = [])
     {
-        return \phln\object\path($path, $object);
+        return \phln\object\path(...func_get_args());
     }
 
     /**
@@ -1405,8 +1405,8 @@ class Phln
      * @phlnSignature String -> a -> {k: v} -> v | a
      * @phlnCategory object
      * @param string $path
-     * @param string $default
-     * @param string|array $object
+     * @param mixed $default
+     * @param array $object
      * @return \Closure|mixed
      * @example
      *      P::pathOr('a.b', 'foo', ['a' => ['b' => 1]]); // 1
@@ -1414,9 +1414,9 @@ class Phln
      *      P::pathOr('a.b', 'foo', ['a' => ['b' => null]]); // 'foo'
      *      P::pathOr('a.b', 'foo', ['a' => 1]); // 'foo'
      */
-    public static function pathOr($path = NULL, $default = NULL, $object = NULL)
+    public static function pathOr(string $path = '', $default = NULL, array $object = [])
     {
-        return \phln\object\pathOr($path, $default, $object);
+        return \phln\object\pathOr(...func_get_args());
     }
 
     /**
@@ -1424,15 +1424,15 @@ class Phln
      *
      * @phlnSignature [String] -> {String: *} -> {String: *}
      * @phlnCategory object
-     * @param string|array $useKeys
-     * @param string|array $object
+     * @param array $useKeys
+     * @param array $object
      * @return \Closure|array
      * @example
      *      P::pick(['a'], ['a' => 1, 'b' => 2]); // ['a' => 1]
      */
-    public static function pick($useKeys = NULL, $object = NULL)
+    public static function pick(array $useKeys = [], array $object = [])
     {
-        return \phln\object\pick($useKeys, $object);
+        return \phln\object\pick(...func_get_args());
     }
 
     /**
@@ -1440,13 +1440,13 @@ class Phln
      *
      * @phlnSignature k -> {k: v} -> v
      * @phlnCategory object
-     * @param string $key
-     * @param string|array $array
+     * @param string|integer $key
+     * @param array $array
      * @return \Closure|mixed
      */
-    public static function prop($key = NULL, $array = NULL)
+    public static function prop($key = '', array $array = [])
     {
-        return \phln\object\prop($key, $array);
+        return \phln\object\prop(...func_get_args());
     }
 
     /**
@@ -1454,16 +1454,16 @@ class Phln
      *
      * @phlnSignature [k] -> {k: v} -> [v]
      * @phlnCategory object
-     * @param string|array $props
-     * @param string|array $object
+     * @param array $props
+     * @param array $object
      * @return \Closure|array
      * @example
      *      $fullName = P::compose(P::join(' '), P::props(['firstName', 'lastName']));
      *      $fullName(['lastName' => 'Snow', 'firstName' => 'Jon']); // 'Jon Snow'
      */
-    public static function props($props = NULL, $object = NULL)
+    public static function props(array $props = [], array $object = [])
     {
-        return \phln\object\props($props, $object);
+        return \phln\object\props(...func_get_args());
     }
 
     /**
@@ -1476,7 +1476,7 @@ class Phln
      */
     public static function values(array $object): array
     {
-        return \phln\object\values($object);
+        return \phln\object\values(...func_get_args());
     }
 
     /**
@@ -1486,8 +1486,8 @@ class Phln
      *
      * @phlnSignature {String: (* -> Boolean)} -> {String: *} -> Boolean
      * @phlnCategory object
-     * @param string|array $predicates
-     * @param string|array $object
+     * @param array $predicates
+     * @param array $object
      * @return \Closure|bool
      * @example
      *      $verifyJon = P::where([
@@ -1497,9 +1497,9 @@ class Phln
      *
      *      $verifyJon(['firstName' => 'Jon', 'lastName' => 'Snow', 'house' => 'Stark']); // true
      */
-    public static function where($predicates = NULL, $object = NULL)
+    public static function where(array $predicates = [], array $object = [])
     {
-        return \phln\object\where($predicates, $object);
+        return \phln\object\where(...func_get_args());
     }
 
     /**
@@ -1507,16 +1507,16 @@ class Phln
      *
      * @phlnSignature {String: *} -> {String: *} -> Boolean
      * @phlnCategory object
-     * @param string $predicates
-     * @param string $object
+     * @param array $predicates
+     * @param array $object
      * @return \Closure|bool
      * @example
      *      $verifyJon = P::whereEq(['firstName' => 'Jon', 'lastName' => 'Snow']);
      *      $verifyJon(['firstName' => 'Jon', 'lastName' => 'Snow']); // true
      */
-    public static function whereEq($predicates = NULL, $object = NULL)
+    public static function whereEq(array $predicates = [], array $object = [])
     {
-        return \phln\object\whereEq($predicates, $object);
+        return \phln\object\whereEq(...func_get_args());
     }
 
     /**
@@ -1535,7 +1535,7 @@ class Phln
      */
     public static function clamp($min = NULL, $max = NULL, $value = NULL)
     {
-        return \phln\relation\clamp($min, $max, $value);
+        return \phln\relation\clamp(...func_get_args());
     }
 
     /**
@@ -1543,15 +1543,15 @@ class Phln
      *
      * @phlnSignature [*] -> [*] -> [*]
      * @phlnCategory relation
-     * @param string|array $a
-     * @param string|array $b
+     * @param array $left
+     * @param array $right
      * @return \Closure|array
      * @example
      *      P::difference([1, 2, 3, 4], [3, 4, 5, 6]); // [1, 2]
      */
-    public static function difference($a = NULL, $b = NULL)
+    public static function difference(array $left = NULL, array $right = NULL)
     {
-        return \phln\relation\difference($a, $b);
+        return \phln\relation\difference(...func_get_args());
     }
 
     /**
@@ -1569,7 +1569,7 @@ class Phln
      */
     public static function equals($a = NULL, $b = NULL)
     {
-        return \phln\relation\equals($a, $b);
+        return \phln\relation\equals(...func_get_args());
     }
 
     /**
@@ -1585,7 +1585,7 @@ class Phln
      */
     public static function gt($a = NULL, $b = NULL)
     {
-        return \phln\relation\gt($a, $b);
+        return \phln\relation\gt(...func_get_args());
     }
 
     /**
@@ -1603,7 +1603,7 @@ class Phln
      */
     public static function gte($a = NULL, $b = NULL)
     {
-        return \phln\relation\gte($a, $b);
+        return \phln\relation\gte(...func_get_args());
     }
 
     /**
@@ -1611,15 +1611,15 @@ class Phln
      *
      * @phlnSignature [*] -> [*] -> [*]
      * @phlnCategory relation
-     * @param string $a
-     * @param string $b
+     * @param array $left
+     * @param array $right
      * @return \Closure|mixed
      * @example
      *      P::intersection([1, 2, 3, 4], [6, 4, 5]); // [4]
      */
-    public static function intersection($a = NULL, $b = NULL)
+    public static function intersection(array $left = [], array $right = [])
     {
-        return \phln\relation\intersection($a, $b);
+        return \phln\relation\intersection(...func_get_args());
     }
 
     /**
@@ -1627,17 +1627,17 @@ class Phln
      *
      * @phlnSignature Ord a => a -> a -> Boolean
      * @phlnCategory relation
-     * @param mixed $a
-     * @param mixed $b
+     * @param mixed $left
+     * @param mixed $right
      * @return \Closure|bool
      * @example
      *      P::lt(1, 2); // true
      *      P::lt(3, 2); // false
      *      P::lt(2, 2); // false
      */
-    public static function lt($a = NULL, $b = NULL)
+    public static function lt($left = NULL, $right = NULL)
     {
-        return \phln\relation\lt($a, $b);
+        return \phln\relation\lt(...func_get_args());
     }
 
     /**
@@ -1645,15 +1645,15 @@ class Phln
      *
      * @phlnSignature Ord a => a -> a -> Boolean
      * @phlnCategory relation
-     * @param string $a
-     * @param string $b
+     * @param mixed $left
+     * @param mixed $right
      * @return \Closure|mixed
      * @example
      *      P::lte(1, 2); // true
      */
-    public static function lte($a = NULL, $b = NULL)
+    public static function lte($left = NULL, $right = NULL)
     {
-        return \phln\relation\lte($a, $b);
+        return \phln\relation\lte(...func_get_args());
     }
 
     /**
@@ -1661,13 +1661,13 @@ class Phln
      *
      * @phlnSignature a -> a -> a
      * @phlnCategory relation
-     * @param string $left
-     * @param string $right
+     * @param mixed $left
+     * @param mixed $right
      * @return \Closure|mixed
      */
     public static function max($left = NULL, $right = NULL)
     {
-        return \phln\relation\max($left, $right);
+        return \phln\relation\max(...func_get_args());
     }
 
     /**
@@ -1675,15 +1675,15 @@ class Phln
      *
      * @phlnSignature a -> a -> a
      * @phlnCategory relation
-     * @param string $left
-     * @param string $right
+     * @param mixed $left
+     * @param mixed $right
      * @return \Closure|mixed
      * @example
      *      P::min(1, -1); // -1
      */
     public static function min($left = NULL, $right = NULL)
     {
-        return \phln\relation\min($left, $right);
+        return \phln\relation\min(...func_get_args());
     }
 
     /**
@@ -1693,14 +1693,14 @@ class Phln
      * @phlnCategory relation
      * @param string $path
      * @param mixed $value
-     * @param string|array $object
+     * @param array $object
      * @return \Closure|bool
      * @example
      *      P::pathEq('foo.bar', 1, ['foo' => ['bar' => 1]]); // true
      */
-    public static function pathEq($path = NULL, $value = NULL, $object = NULL)
+    public static function pathEq(string $path = '', $value = NULL, array $object = [])
     {
-        return \phln\relation\pathEq($path, $value, $object);
+        return \phln\relation\pathEq(...func_get_args());
     }
 
     /**
@@ -1709,15 +1709,15 @@ class Phln
      * @phlnSignature k -> a -> {k: a} -> Boolean
      * @phlnCategory relation
      * @param string $prop
-     * @param string $value
-     * @param string $object
+     * @param mixed $value
+     * @param array $object
      * @return \Closure|mixed
      * @example
      *      P::propEq('name', 'Jon', ['name' => 'Jon']); // true
      */
-    public static function propEq($prop = NULL, $value = NULL, $object = NULL)
+    public static function propEq(string $prop = '', $value = NULL, array $object = NULL)
     {
-        return \phln\relation\propEq($prop, $value, $object);
+        return \phln\relation\propEq(...func_get_args());
     }
 
     /**
@@ -1733,9 +1733,9 @@ class Phln
      *      P::match('/([a-z](o))/i', 'Lorem ipsum dolor'); // 'Lo'
      *      P::match('/([a-z](o))/ig', 'Lorem ipsum dolor'); // ['Lo', 'do', 'lo']
      */
-    public static function match($regexp = NULL, $test = NULL)
+    public static function match($regexp = NULL, string $test = '')
     {
-        return \phln\string\match($regexp, $test);
+        return \phln\string\match(...func_get_args());
     }
 
     /**
@@ -1750,7 +1750,7 @@ class Phln
      */
     public static function regexp(string $regexp): \phln\RegExp
     {
-        return \phln\string\regexp($regexp);
+        return \phln\string\regexp(...func_get_args());
     }
 
     /**
@@ -1761,7 +1761,7 @@ class Phln
      *
      * @phlnSignature RegExp -> String -> String -> String
      * @phlnCategory string
-     * @param string $regexp
+     * @param string|RegExp $regexp
      * @param string $replacement
      * @param string $text
      * @return \Closure|string
@@ -1769,9 +1769,9 @@ class Phln
      *      P::replace('/foo/', 'bar', 'foo foo foo'); // 'bar foo foo'
      *      P::replace('/foo/g', 'bar', 'foo foo foo'); // 'bar bar bar'
      */
-    public static function replace($regexp = NULL, $replacement = NULL, $text = NULL)
+    public static function replace($regexp = NULL, string $replacement = '', string $text = '')
     {
-        return \phln\string\replace($regexp, $replacement, $text);
+        return \phln\string\replace(...func_get_args());
     }
 
     /**
@@ -1782,15 +1782,15 @@ class Phln
      * @phlnSignature String -> String -> [String]
      * @phlnSignature RegExp -> String -> [String]
      * @phlnCategory string
-     * @param string $delimiter
+     * @param string|RegExp $delimiter
      * @param string $text
      * @return \Closure|array
      * @example
      *      P::split('/', 'a/b'); // ['a', 'b']
      */
-    public static function split($delimiter = NULL, $text = NULL)
+    public static function split($delimiter = NULL, string $text = '')
     {
-        return \phln\string\split($delimiter, $text);
+        return \phln\string\split(...func_get_args());
     }
 
     /**
@@ -1813,9 +1813,9 @@ class Phln
      *      P::is(\stdClass::class, new \stdClass); // true
      *      P::is(float, 1.1); // true
      */
-    public static function is($type = NULL, $value = NULL)
+    public static function is(string $type = '', $value = NULL)
     {
-        return \phln\type\is($type, $value);
+        return \phln\type\is(...func_get_args());
     }
 
     /**
@@ -1838,7 +1838,7 @@ class Phln
      */
     public static function typeCond(array $pairs): \Closure
     {
-        return \phln\type\typeCond($pairs);
+        return \phln\type\typeCond(...func_get_args());
     }
 
 }

--- a/src/Phln.php
+++ b/src/Phln.php
@@ -7,8 +7,6 @@ declare(strict_types=1);
 
 namespace phln;
 
-use const phln\fn\nil;
-
 class Phln
 {
     const all = \phln\collection\all;
@@ -49,7 +47,6 @@ class Phln
     const arity = \phln\fn\arity;
     const compose = \phln\fn\compose;
     const curry = \phln\fn\curry;
-    const nil = \phln\fn\nil;
     const curryN = \phln\fn\curryN;
     const identity = \phln\fn\identity;
     const negate = \phln\fn\negate;
@@ -124,7 +121,7 @@ class Phln
      *      $onlyTwos = P::all(P::equals(2));
      *      $onlyTwos([1, 2, 2]); // false
      */
-    public static function all($predicate = nil, $list = nil)
+    public static function all($predicate = NULL, $list = NULL)
     {
         return \phln\collection\all($predicate, $list);
     }
@@ -141,7 +138,7 @@ class Phln
      *      $hasTwos = P::any(P::equals(2));
      *      $hasTwos([1, 2, 3, 4]); // true
      */
-    public static function any($predicate = nil, $list = nil)
+    public static function any($predicate = NULL, $list = NULL)
     {
         return \phln\collection\any($predicate, $list);
     }
@@ -160,7 +157,7 @@ class Phln
      *      P::append([3], [1, 2]); // [1, 2, [3]]
      *      P::append('foo', 'bar'); // 'barfoo'
      */
-    public static function append($value = nil, $collection = nil)
+    public static function append($value = NULL, $collection = NULL)
     {
         return \phln\collection\append($value, $collection);
     }
@@ -179,7 +176,7 @@ class Phln
      *      P::chunk(2, [1, 2, 3, 4]); // [[1, 2], [3, 4]]
      *      P::chunk(2, 'hello'); // ['he', 'll', 'o']
      */
-    public static function chunk($size = nil, $collection = nil)
+    public static function chunk($size = NULL, $collection = NULL)
     {
         return \phln\collection\chunk($size, $collection);
     }
@@ -213,7 +210,7 @@ class Phln
      *      P::concat([1, 2], [3]); // [1, 2, 3]
      *      P::concat('foo', 'bar'); // 'foobar'
      */
-    public static function concat($a = nil, $b = nil)
+    public static function concat($a = NULL, $b = NULL)
     {
         return \phln\collection\concat($a, $b);
     }
@@ -232,7 +229,7 @@ class Phln
      *      P::contains(1, [1, 2, 3]); // true
      *      P::contains('foo', 'foobar'); // true
      */
-    public static function contains($value = nil, $collection = nil)
+    public static function contains($value = NULL, $collection = NULL)
     {
         return \phln\collection\contains($value, $collection);
     }
@@ -248,7 +245,7 @@ class Phln
      * @example
      *      P::filter(equals(1), [1, 2, 3]); // [1]
      */
-    public static function filter($predicate = nil, $list = nil)
+    public static function filter($predicate = NULL, $list = NULL)
     {
         return \phln\collection\filter($predicate, $list);
     }
@@ -266,7 +263,7 @@ class Phln
      *      $xs = [['a' => 1], ['a' => 2], ['a' => 3]];
      *      P::find(equals(['a' => 1]), $xs); // ['a' => 1]
      */
-    public static function find($predicate = nil, $list = nil)
+    public static function find($predicate = NULL, $list = NULL)
     {
         return \phln\collection\find($predicate, $list);
     }
@@ -286,7 +283,7 @@ class Phln
      *
      *      $duplicateElements([1, 2]); // [1, 1, 2, 2]
      */
-    public static function flatMap($mapper = nil, $list = nil)
+    public static function flatMap($mapper = NULL, $list = NULL)
     {
         return \phln\collection\flatMap($mapper, $list);
     }
@@ -346,7 +343,7 @@ class Phln
      *      $spacer = P::join(' ');
      *      $spacer([1, 2, 3]); // '1 2 3'
      */
-    public static function join($separator = nil, $list = nil)
+    public static function join($separator = NULL, $list = NULL)
     {
         return \phln\collection\join($separator, $list);
     }
@@ -395,7 +392,7 @@ class Phln
      * @param string|array $list
      * @return \Closure|array
      */
-    public static function map($fn = nil, $list = nil)
+    public static function map($fn = NULL, $list = NULL)
     {
         return \phln\collection\map($fn, $list);
     }
@@ -411,7 +408,7 @@ class Phln
      * @param string|array $list
      * @return \Closure|array
      */
-    public static function mapIndexed($fn = nil, $list = nil)
+    public static function mapIndexed($fn = NULL, $list = NULL)
     {
         return \phln\collection\mapIndexed($fn, $list);
     }
@@ -432,7 +429,7 @@ class Phln
      *      P::none($isEven, [1, 3, 5]); // true
      *      P::none($isEven, [1, 3, 5, 6]); // false
      */
-    public static function none($predicate = nil, $list = nil)
+    public static function none($predicate = NULL, $list = NULL)
     {
         return \phln\collection\none($predicate, $list);
     }
@@ -450,7 +447,7 @@ class Phln
      *      P::nth(1, [1, 2, 3]); // 2
      *      P::nth(-1, [1, 2, 3]); // 3
      */
-    public static function nth($n = nil, $list = nil)
+    public static function nth($n = NULL, $list = NULL)
     {
         return \phln\collection\nth($n, $list);
     }
@@ -467,7 +464,7 @@ class Phln
      *      $list = [['a' => 1], ['a' => 2]];
      *      P::pluck('a', $list); // [1, 2]
      */
-    public static function pluck($key = nil, $list = nil)
+    public static function pluck($key = NULL, $list = NULL)
     {
         return \phln\collection\pluck($key, $list);
     }
@@ -486,7 +483,7 @@ class Phln
      *      P::prepend([3], [1, 2]); // [[3], 1, 2]
      *      P::prepend('foo', 'bar'); // [[3], 1, 2]
      */
-    public static function prepend($value = nil, $collection = nil)
+    public static function prepend($value = NULL, $collection = NULL)
     {
         return \phln\collection\prepend($value, $collection);
     }
@@ -502,7 +499,7 @@ class Phln
      * @example
      *      P::range(0, 3); // [0, 1, 2]
      */
-    public static function range($start = nil, $end = nil)
+    public static function range($start = NULL, $end = NULL)
     {
         return \phln\collection\range($start, $end);
     }
@@ -522,7 +519,7 @@ class Phln
      *      P::reduce(P::subtract, 0, [1, 2, 3, 4]);
      *      // ((((0 - 1) - 2) - 3) - 4) => -10
      */
-    public static function reduce($reducer = nil, $initialValue = nil, $list = nil)
+    public static function reduce($reducer = NULL, $initialValue = NULL, $list = NULL)
     {
         return \phln\collection\reduce($reducer, $initialValue, $list);
     }
@@ -541,7 +538,7 @@ class Phln
      *      };
      *      P::reject($isOdd, [1, 2, 3, 4]); // [2, 4]
      */
-    public static function reject($predicate = nil, $list = nil)
+    public static function reject($predicate = NULL, $list = NULL)
     {
         return \phln\collection\reject($predicate, $list);
     }
@@ -581,7 +578,7 @@ class Phln
      *      $takeTwo = P::slice(0, 2);
      *      $takeTwo([1, 2, 3]); // [1, 2]
      */
-    public static function slice($offset = nil, $length = nil, $collection = nil)
+    public static function slice($offset = NULL, $length = NULL, $collection = NULL)
     {
         return \phln\collection\slice($offset, $length, $collection);
     }
@@ -602,7 +599,7 @@ class Phln
      *
      *      P::sort($diff, [3, 2, 1]); // [1, 2, 3]
      */
-    public static function sort($comparator = nil, $list = nil)
+    public static function sort($comparator = NULL, $list = NULL)
     {
         return \phln\collection\sort($comparator, $list);
     }
@@ -624,7 +621,7 @@ class Phln
      *
      *      P::soryBy(P::prop('name'), $people); // [$alice, $bob, $clara]
      */
-    public static function sortBy($mapper = nil, $list = nil)
+    public static function sortBy($mapper = NULL, $list = NULL)
     {
         return \phln\collection\sortBy($mapper, $list);
     }
@@ -717,7 +714,7 @@ class Phln
      * @example
      *      P::apply(P::sum, [1, 2]); // 3
      */
-    public static function apply($fn = nil, $arguments = nil)
+    public static function apply($fn = NULL, $arguments = NULL)
     {
         return \phln\fn\apply($fn, $arguments);
     }
@@ -880,7 +877,7 @@ class Phln
      *      $subtractFive = P::partial(P::subtract, P::__, 5);
      *      $subtractFive(10); // 5
      */
-    public static function partial($fn = nil, $args = nil): \Closure
+    public static function partial($fn = NULL, $args = NULL): \Closure
     {
         return \phln\fn\partial($fn, $args);
     }
@@ -932,7 +929,7 @@ class Phln
      *      $dump = P::tap('var_dump');
      *      $dump('foo'); // var_dumps('foo'); returns 'foo'
      */
-    public static function tap($fn = nil, $value = nil)
+    public static function tap($fn = NULL, $value = NULL)
     {
         return \phln\fn\tap($fn, $value);
     }
@@ -971,7 +968,7 @@ class Phln
      * @example
      *      P::unapply('\\json_encode')(1, 2, 3); // [1,2,3]
      */
-    public static function unapply($fn = nil, ...$args)
+    public static function unapply($fn = NULL, ...$args)
     {
         return \phln\fn\unapply($fn, ...$args);
     }
@@ -1016,7 +1013,7 @@ class Phln
      *      $f(12); // true
      *      P::both(true, false); // false
      */
-    public static function both($left = nil, $right = nil)
+    public static function both($left = NULL, $right = NULL)
     {
         return \phln\logic\both($left, $right);
     }
@@ -1058,7 +1055,7 @@ class Phln
      *      P::defaultTo(42, null); // 42
      *      P::defaultTo(42, 'life'); // 'life'
      */
-    public static function defaultTo($default = nil, $value = nil)
+    public static function defaultTo($default = NULL, $value = NULL)
     {
         return \phln\logic\defaultTo($default, $value);
     }
@@ -1085,7 +1082,7 @@ class Phln
      *      $f(21); // true
      *      P::either(true, false); // true
      */
-    public static function either($left = nil, $right = nil)
+    public static function either($left = NULL, $right = NULL)
     {
         return \phln\logic\either($left, $right);
     }
@@ -1110,7 +1107,7 @@ class Phln
      *      $fizzbuzz(15); // 'fizzbuzz'
      *      $fizzbuzz(1); // 1
      */
-    public static function ifElse($predicate = nil, $onTrue = nil, $onFalse = nil): \Closure
+    public static function ifElse($predicate = NULL, $onTrue = NULL, $onFalse = NULL): \Closure
     {
         return \phln\logic\ifElse($predicate, $onTrue, $onFalse);
     }
@@ -1163,7 +1160,7 @@ class Phln
      * @param mixed $b
      * @return \Closure|mixed
      */
-    public static function add($a = nil, $b = nil)
+    public static function add($a = NULL, $b = NULL)
     {
         return \phln\math\add($a, $b);
     }
@@ -1190,7 +1187,7 @@ class Phln
      * @param mixed $b
      * @return \Closure|mixed
      */
-    public static function divide($a = nil, $b = nil)
+    public static function divide($a = NULL, $b = NULL)
     {
         return \phln\math\divide($a, $b);
     }
@@ -1250,7 +1247,7 @@ class Phln
      * @example
      *      \\phln\\math\\modulo(1, 2) // 1
      */
-    public static function modulo($a = nil, $b = nil)
+    public static function modulo($a = NULL, $b = NULL)
     {
         return \phln\math\modulo($a, $b);
     }
@@ -1267,7 +1264,7 @@ class Phln
      *      $triple = P::multiply(3);
      *      $triple(7); // 21
      */
-    public static function multiply($a = nil, $b = nil)
+    public static function multiply($a = NULL, $b = NULL)
     {
         return \phln\math\multiply($a, $b);
     }
@@ -1299,7 +1296,7 @@ class Phln
      *      $complementaryAngle = P::subtract(90);
      *      $complementaryAngle(30); //=> 60
      */
-    public static function subtract($a = nil, $b = nil)
+    public static function subtract($a = NULL, $b = NULL)
     {
         return \phln\math\subtract($a, $b);
     }
@@ -1331,7 +1328,7 @@ class Phln
      * @example
      *      P::eqProps('name', ['name' => 'Jon'], ['name' => 'Jon']); // true
      */
-    public static function eqProps($prop = nil, $a = nil, $b = nil)
+    public static function eqProps($prop = NULL, $a = NULL, $b = NULL)
     {
         return \phln\object\eqProps($prop, $a, $b);
     }
@@ -1364,7 +1361,7 @@ class Phln
      *      $toDefaults = P::partial(P::merge, [P::__, ['x' => 0]);
      *      $toDefaults(['x' => 2, 'y' => 1]); // ['x' => 0, 'y' => 1]
      */
-    public static function merge($left = nil, $right = nil)
+    public static function merge($left = NULL, $right = NULL)
     {
         return \phln\object\merge($left, $right);
     }
@@ -1380,7 +1377,7 @@ class Phln
      * @example
      *      P::omit(['a', 'c'], ['a' => 1, 'b' => 2, 'c' => 3]); // ['b' => 2]
      */
-    public static function omit($omitKeys = nil, $object = nil)
+    public static function omit($omitKeys = NULL, $object = NULL)
     {
         return \phln\object\omit($omitKeys, $object);
     }
@@ -1397,7 +1394,7 @@ class Phln
      *      P::path('a.b', ['a' => ['b' => 'foo']]); // 'foo'
      *      P::path('a.b.c', ['a' => ['b' => 'foo']]); // null
      */
-    public static function path($path = nil, $object = nil)
+    public static function path($path = NULL, $object = NULL)
     {
         return \phln\object\path($path, $object);
     }
@@ -1417,7 +1414,7 @@ class Phln
      *      P::pathOr('a.b', 'foo', ['a' => ['b' => null]]); // 'foo'
      *      P::pathOr('a.b', 'foo', ['a' => 1]); // 'foo'
      */
-    public static function pathOr($path = nil, $default = nil, $object = nil)
+    public static function pathOr($path = NULL, $default = NULL, $object = NULL)
     {
         return \phln\object\pathOr($path, $default, $object);
     }
@@ -1433,7 +1430,7 @@ class Phln
      * @example
      *      P::pick(['a'], ['a' => 1, 'b' => 2]); // ['a' => 1]
      */
-    public static function pick($useKeys = nil, $object = nil)
+    public static function pick($useKeys = NULL, $object = NULL)
     {
         return \phln\object\pick($useKeys, $object);
     }
@@ -1447,7 +1444,7 @@ class Phln
      * @param string|array $array
      * @return \Closure|mixed
      */
-    public static function prop($key = nil, $array = nil)
+    public static function prop($key = NULL, $array = NULL)
     {
         return \phln\object\prop($key, $array);
     }
@@ -1464,7 +1461,7 @@ class Phln
      *      $fullName = P::compose(P::join(' '), P::props(['firstName', 'lastName']));
      *      $fullName(['lastName' => 'Snow', 'firstName' => 'Jon']); // 'Jon Snow'
      */
-    public static function props($props = nil, $object = nil)
+    public static function props($props = NULL, $object = NULL)
     {
         return \phln\object\props($props, $object);
     }
@@ -1500,7 +1497,7 @@ class Phln
      *
      *      $verifyJon(['firstName' => 'Jon', 'lastName' => 'Snow', 'house' => 'Stark']); // true
      */
-    public static function where($predicates = nil, $object = nil)
+    public static function where($predicates = NULL, $object = NULL)
     {
         return \phln\object\where($predicates, $object);
     }
@@ -1517,7 +1514,7 @@ class Phln
      *      $verifyJon = P::whereEq(['firstName' => 'Jon', 'lastName' => 'Snow']);
      *      $verifyJon(['firstName' => 'Jon', 'lastName' => 'Snow']); // true
      */
-    public static function whereEq($predicates = nil, $object = nil)
+    public static function whereEq($predicates = NULL, $object = NULL)
     {
         return \phln\object\whereEq($predicates, $object);
     }
@@ -1536,7 +1533,7 @@ class Phln
      *      P::clamp(-1, 1, 100); // 1
      *      P::clamp(-1, 1, 0); // 0
      */
-    public static function clamp($min = nil, $max = nil, $value = nil)
+    public static function clamp($min = NULL, $max = NULL, $value = NULL)
     {
         return \phln\relation\clamp($min, $max, $value);
     }
@@ -1552,7 +1549,7 @@ class Phln
      * @example
      *      P::difference([1, 2, 3, 4], [3, 4, 5, 6]); // [1, 2]
      */
-    public static function difference($a = nil, $b = nil)
+    public static function difference($a = NULL, $b = NULL)
     {
         return \phln\relation\difference($a, $b);
     }
@@ -1570,7 +1567,7 @@ class Phln
      *      P::equals(1, '1'); // false
      *      P::equals(1, 2); // false
      */
-    public static function equals($a = nil, $b = nil)
+    public static function equals($a = NULL, $b = NULL)
     {
         return \phln\relation\equals($a, $b);
     }
@@ -1586,7 +1583,7 @@ class Phln
      * @example
      *      P::gt(2, 1); // true
      */
-    public static function gt($a = nil, $b = nil)
+    public static function gt($a = NULL, $b = NULL)
     {
         return \phln\relation\gt($a, $b);
     }
@@ -1604,7 +1601,7 @@ class Phln
      *      P::gte(2, 2); // true
      *      P::gte(2, 3); // false
      */
-    public static function gte($a = nil, $b = nil)
+    public static function gte($a = NULL, $b = NULL)
     {
         return \phln\relation\gte($a, $b);
     }
@@ -1620,7 +1617,7 @@ class Phln
      * @example
      *      P::intersection([1, 2, 3, 4], [6, 4, 5]); // [4]
      */
-    public static function intersection($a = nil, $b = nil)
+    public static function intersection($a = NULL, $b = NULL)
     {
         return \phln\relation\intersection($a, $b);
     }
@@ -1638,7 +1635,7 @@ class Phln
      *      P::lt(3, 2); // false
      *      P::lt(2, 2); // false
      */
-    public static function lt($a = nil, $b = nil)
+    public static function lt($a = NULL, $b = NULL)
     {
         return \phln\relation\lt($a, $b);
     }
@@ -1654,7 +1651,7 @@ class Phln
      * @example
      *      P::lte(1, 2); // true
      */
-    public static function lte($a = nil, $b = nil)
+    public static function lte($a = NULL, $b = NULL)
     {
         return \phln\relation\lte($a, $b);
     }
@@ -1668,7 +1665,7 @@ class Phln
      * @param string $right
      * @return \Closure|mixed
      */
-    public static function max($left = nil, $right = nil)
+    public static function max($left = NULL, $right = NULL)
     {
         return \phln\relation\max($left, $right);
     }
@@ -1684,7 +1681,7 @@ class Phln
      * @example
      *      P::min(1, -1); // -1
      */
-    public static function min($left = nil, $right = nil)
+    public static function min($left = NULL, $right = NULL)
     {
         return \phln\relation\min($left, $right);
     }
@@ -1701,7 +1698,7 @@ class Phln
      * @example
      *      P::pathEq('foo.bar', 1, ['foo' => ['bar' => 1]]); // true
      */
-    public static function pathEq($path = nil, $value = nil, $object = nil)
+    public static function pathEq($path = NULL, $value = NULL, $object = NULL)
     {
         return \phln\relation\pathEq($path, $value, $object);
     }
@@ -1718,7 +1715,7 @@ class Phln
      * @example
      *      P::propEq('name', 'Jon', ['name' => 'Jon']); // true
      */
-    public static function propEq($prop = nil, $value = nil, $object = nil)
+    public static function propEq($prop = NULL, $value = NULL, $object = NULL)
     {
         return \phln\relation\propEq($prop, $value, $object);
     }
@@ -1736,7 +1733,7 @@ class Phln
      *      P::match('/([a-z](o))/i', 'Lorem ipsum dolor'); // 'Lo'
      *      P::match('/([a-z](o))/ig', 'Lorem ipsum dolor'); // ['Lo', 'do', 'lo']
      */
-    public static function match($regexp = nil, $test = nil)
+    public static function match($regexp = NULL, $test = NULL)
     {
         return \phln\string\match($regexp, $test);
     }
@@ -1772,7 +1769,7 @@ class Phln
      *      P::replace('/foo/', 'bar', 'foo foo foo'); // 'bar foo foo'
      *      P::replace('/foo/g', 'bar', 'foo foo foo'); // 'bar bar bar'
      */
-    public static function replace($regexp = nil, $replacement = nil, $text = nil)
+    public static function replace($regexp = NULL, $replacement = NULL, $text = NULL)
     {
         return \phln\string\replace($regexp, $replacement, $text);
     }
@@ -1791,7 +1788,7 @@ class Phln
      * @example
      *      P::split('/', 'a/b'); // ['a', 'b']
      */
-    public static function split($delimiter = nil, $text = nil)
+    public static function split($delimiter = NULL, $text = NULL)
     {
         return \phln\string\split($delimiter, $text);
     }
@@ -1816,7 +1813,7 @@ class Phln
      *      P::is(\stdClass::class, new \stdClass); // true
      *      P::is(float, 1.1); // true
      */
-    public static function is($type = nil, $value = nil)
+    public static function is($type = NULL, $value = NULL)
     {
         return \phln\type\is($type, $value);
     }

--- a/src/collection/all.php
+++ b/src/collection/all.php
@@ -13,16 +13,16 @@ const 𝑓all = '\\phln\\collection\\𝑓all';
  *
  * @phlnSignature (a -> Boolean) -> [a] -> Boolean
  * @phlnCategory collection
- * @param string $predicate
- * @param string $list
+ * @param callable $predicate
+ * @param array $list
  * @return \Closure|bool
  * @example
  *      $onlyTwos = \phln\collection\all(\phln\relation\equals(2));
  *      $onlyTwos([1, 2, 2]); // false
  */
-function all($predicate = null, $list = null)
+function all(callable $predicate = null, array $list = [])
 {
-    return curryN(2, 𝑓all, [$predicate, $list]);
+    return curryN(2, 𝑓all, func_get_args());
 }
 
 function 𝑓all(callable $predicate, array $list): bool

--- a/src/collection/all.php
+++ b/src/collection/all.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\collection;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const all = '\\phln\\collection\\all';
@@ -21,7 +20,7 @@ const 𝑓all = '\\phln\\collection\\𝑓all';
  *      $onlyTwos = \phln\collection\all(\phln\relation\equals(2));
  *      $onlyTwos([1, 2, 2]); // false
  */
-function all($predicate = nil, $list = nil)
+function all($predicate = null, $list = null)
 {
     return curryN(2, 𝑓all, [$predicate, $list]);
 }

--- a/src/collection/any.php
+++ b/src/collection/any.php
@@ -13,16 +13,16 @@ const 𝑓any = '\\phln\\collection\\𝑓any';
  *
  * @phlnSignature (a -> Boolean) -> [a] -> Boolean
  * @phlnCategory collection
- * @param string $predicate
- * @param string $list
+ * @param callable $predicate
+ * @param array $list
  * @return \Closure|bool
  * @example
  *      $hasTwos = \phln\collection\any(\phln\relation\equals(2));
  *      $hasTwos([1, 2, 3, 4]); // true
  */
-function any($predicate = null, $list = null)
+function any(callable $predicate = null, array $list = [])
 {
-    return curryN(2, 𝑓any, [$predicate, $list]);
+    return curryN(2, 𝑓any, func_get_args());
 }
 
 function 𝑓any(callable $predicate, array $list): bool

--- a/src/collection/any.php
+++ b/src/collection/any.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\collection;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const any = '\\phln\\collection\\any';
@@ -21,7 +20,7 @@ const 𝑓any = '\\phln\\collection\\𝑓any';
  *      $hasTwos = \phln\collection\any(\phln\relation\equals(2));
  *      $hasTwos([1, 2, 3, 4]); // true
  */
-function any($predicate = nil, $list = nil)
+function any($predicate = null, $list = null)
 {
     return curryN(2, 𝑓any, [$predicate, $list]);
 }

--- a/src/collection/append.php
+++ b/src/collection/append.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace phln\collection;
 
 use const phln\fn\{
-    __, nil, otherwise
+    __, otherwise
 };
 use function phln\fn\{
     curryN, partial, throwException
@@ -28,7 +28,7 @@ const 𝑓append = '\\phln\\collection\\𝑓append';
  *      \phln\collection\append([3], [1, 2]); // [1, 2, [3]]
  *      \phln\collection\append('foo', 'bar'); // 'barfoo'
  */
-function append($value = nil, $collection = nil)
+function append($value = null, $collection = null)
 {
     return curryN(2, 𝑓append, [$value, $collection]);
 }

--- a/src/collection/append.php
+++ b/src/collection/append.php
@@ -21,7 +21,7 @@ const 𝑓append = '\\phln\\collection\\𝑓append';
  * @phlnSignature String -> String -> String
  * @phlnCategory collection
  * @param mixed $value
- * @param string|array $collection
+ * @param array|string $collection
  * @return \Closure|string|array
  * @example
  *      \phln\collection\append(3, [1, 2]); // [1, 2, 3]
@@ -30,7 +30,7 @@ const 𝑓append = '\\phln\\collection\\𝑓append';
  */
 function append($value = null, $collection = null)
 {
-    return curryN(2, 𝑓append, [$value, $collection]);
+    return curryN(2, 𝑓append, func_get_args());
 }
 
 function 𝑓append($value, $collection)

--- a/src/collection/chunk.php
+++ b/src/collection/chunk.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace phln\collection;
 
 use const phln\fn\{
-    __, nil, otherwise
+    __, otherwise
 };
 use function phln\fn\{
     curryN, partial, throwException
@@ -28,7 +28,7 @@ const 𝑓chunk = '\\phln\\collection\\𝑓chunk';
  *      \phln\collection\chunk(2, [1, 2, 3, 4]); // [[1, 2], [3, 4]]
  *      \phln\collection\chunk(2, 'hello'); // ['he', 'll', 'o']
  */
-function chunk($size = nil, $collection = nil)
+function chunk($size = null, $collection = null)
 {
     return curryN(2, 𝑓chunk, [$size, $collection]);
 }

--- a/src/collection/chunk.php
+++ b/src/collection/chunk.php
@@ -21,16 +21,16 @@ const 𝑓chunk = '\\phln\\collection\\𝑓chunk';
  * @phlnSignature Number -> [a] -> [[a]]
  * @phlnSignature Number -> String -> [String]
  * @phlnCategory collection
- * @param string|integer $size
- * @param string|array $collection
+ * @param integer $size
+ * @param array|string $collection
  * @return \Closure|array
  * @example
  *      \phln\collection\chunk(2, [1, 2, 3, 4]); // [[1, 2], [3, 4]]
  *      \phln\collection\chunk(2, 'hello'); // ['he', 'll', 'o']
  */
-function chunk($size = null, $collection = null)
+function chunk(int $size = 0, $collection = null)
 {
-    return curryN(2, 𝑓chunk, [$size, $collection]);
+    return curryN(2, 𝑓chunk, func_get_args());
 }
 
 function 𝑓chunk(int $size, $collection)

--- a/src/collection/concat.php
+++ b/src/collection/concat.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\collection;
 
-use const phln\fn\nil;
 use const phln\fn\otherwise;
 use function phln\fn\{
     compose, curryN, throwException, unapply
@@ -30,7 +29,7 @@ const 𝑓concat = '\\phln\\collection\\𝑓concat';
  *      \phln\collection\concat([1, 2], [3]); // [1, 2, 3]
  *      \phln\collection\concat('foo', 'bar'); // 'foobar'
  */
-function concat($a = nil, $b = nil)
+function concat($a = null, $b = null)
 {
     return curryN(2, 𝑓concat, [$a, $b]);
 }

--- a/src/collection/concat.php
+++ b/src/collection/concat.php
@@ -31,7 +31,7 @@ const 𝑓concat = '\\phln\\collection\\𝑓concat';
  */
 function concat($a = null, $b = null)
 {
-    return curryN(2, 𝑓concat, [$a, $b]);
+    return curryN(2, 𝑓concat, func_get_args());
 }
 
 function 𝑓concat($a, $b)

--- a/src/collection/contains.php
+++ b/src/collection/contains.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace phln\collection;
 
 use const phln\fn\{
-    __, F, nil, otherwise, T
+    __, F, otherwise, T
 };
 use function phln\fn\{
     curryN, partial
@@ -30,7 +30,7 @@ const 𝑓contains = '\\phln\\collection\\𝑓contains';
  *      \phln\collection\contains(1, [1, 2, 3]); // true
  *      \phln\collection\contains('foo', 'foobar'); // true
  */
-function contains($value = nil, $collection = nil)
+function contains($value = null, $collection = null)
 {
     return curryN(2, 𝑓contains, [$value, $collection]);
 }

--- a/src/collection/contains.php
+++ b/src/collection/contains.php
@@ -24,7 +24,7 @@ const 𝑓contains = '\\phln\\collection\\𝑓contains';
  * @phlnSignature String -> String -> Boolean
  * @phlnCategory collection
  * @param mixed $value
- * @param string|array $collection
+ * @param array|string $collection
  * @return \Closure|bool
  * @example
  *      \phln\collection\contains(1, [1, 2, 3]); // true
@@ -32,7 +32,7 @@ const 𝑓contains = '\\phln\\collection\\𝑓contains';
  */
 function contains($value = null, $collection = null)
 {
-    return curryN(2, 𝑓contains, [$value, $collection]);
+    return curryN(2, 𝑓contains, func_get_args());
 }
 
 function 𝑓contains($value, $collection): bool

--- a/src/collection/filter.php
+++ b/src/collection/filter.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\collection;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const filter = '\\phln\\collection\\filter';
@@ -20,7 +19,7 @@ const 𝑓filter = '\\phln\\collection\\𝑓filter';
  * @example
  *      \phln\collection\filter(equals(1), [1, 2, 3]); // [1]
  */
-function filter($predicate = nil, $list = nil)
+function filter($predicate = null, $list = null)
 {
     return curryN(2, 𝑓filter, [$predicate, $list]);
 }

--- a/src/collection/filter.php
+++ b/src/collection/filter.php
@@ -13,15 +13,15 @@ const 𝑓filter = '\\phln\\collection\\𝑓filter';
  *
  * @phlnSignature (a -> Boolean) -> [a] -> Boolean
  * @phlnCategory collection
- * @param string $predicate
- * @param string $list
+ * @param callable $predicate
+ * @param array $list
  * @return \Closure|mixed
  * @example
  *      \phln\collection\filter(equals(1), [1, 2, 3]); // [1]
  */
-function filter($predicate = null, $list = null)
+function filter(callable $predicate = null, array $list = [])
 {
-    return curryN(2, 𝑓filter, [$predicate, $list]);
+    return curryN(2, 𝑓filter, func_get_args());
 }
 
 function 𝑓filter(callable $predicate, array $list): array

--- a/src/collection/find.php
+++ b/src/collection/find.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace phln\collection;
 
 use function phln\fn\curryN;
-use const phln\fn\nil;
 
 const find = '\\phln\\collection\\find';
 const 𝑓find = '\\phln\\collection\\𝑓find';
@@ -22,7 +21,7 @@ const 𝑓find = '\\phln\\collection\\𝑓find';
  *      $xs = [['a' => 1], ['a' => 2], ['a' => 3]];
  *      \phln\collection\find(equals(['a' => 1]), $xs); // ['a' => 1]
  */
-function find($predicate = nil, $list = nil)
+function find($predicate = null, $list = null)
 {
     return curryN(2, 𝑓find, [$predicate, $list]);
 }

--- a/src/collection/find.php
+++ b/src/collection/find.php
@@ -14,16 +14,16 @@ const 𝑓find = '\\phln\\collection\\𝑓find';
  *
  * @phlnSignature (a -> Boolean) -> [a] -> a
  * @phlnCategory collection
- * @param string $predicate
- * @param string $list
+ * @param callable $predicate
+ * @param array $list
  * @return \Closure|mixed
  * @example
  *      $xs = [['a' => 1], ['a' => 2], ['a' => 3]];
  *      \phln\collection\find(equals(['a' => 1]), $xs); // ['a' => 1]
  */
-function find($predicate = null, $list = null)
+function find(callable $predicate = null, array $list = [])
 {
-    return curryN(2, 𝑓find, [$predicate, $list]);
+    return curryN(2, 𝑓find, func_get_args());
 }
 
 function 𝑓find(callable $predicate, array $list)

--- a/src/collection/flatMap.php
+++ b/src/collection/flatMap.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\collection;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 use function phln\fn\pipe;
 
@@ -25,7 +24,7 @@ const 𝑓flatMap = '\\phln\\collection\\𝑓flatMap';
  *
  *      $duplicateElements([1, 2]); // [1, 1, 2, 2]
  */
-function flatMap($mapper = nil, $list = nil)
+function flatMap($mapper = null, $list = null)
 {
     return curryN(2, 𝑓flatMap, [$mapper, $list]);
 }

--- a/src/collection/flatMap.php
+++ b/src/collection/flatMap.php
@@ -14,8 +14,8 @@ const 𝑓flatMap = '\\phln\\collection\\𝑓flatMap';
  *
  * @phlnSignature (a -> b) -> [a] -> [b]
  * @phlnCategory collection
- * @param string $mapper
- * @param string $list
+ * @param callable $mapper
+ * @param array $list
  * @return \Closure|mixed
  * @example
  *      $duplicateElements = \phln\collection\flatMap(function ($i) {
@@ -24,9 +24,9 @@ const 𝑓flatMap = '\\phln\\collection\\𝑓flatMap';
  *
  *      $duplicateElements([1, 2]); // [1, 1, 2, 2]
  */
-function flatMap($mapper = null, $list = null)
+function flatMap(callable $mapper = null, array $list = [])
 {
-    return curryN(2, 𝑓flatMap, [$mapper, $list]);
+    return curryN(2, 𝑓flatMap, func_get_args());
 }
 
 function 𝑓flatMap(callable $mapper, array $list): array

--- a/src/collection/join.php
+++ b/src/collection/join.php
@@ -14,13 +14,13 @@ const 𝑓join = '\\join';
  * @phlnSignature String -> [a] -> String
  * @phlnCategory collection
  * @param string $separator
- * @param string $list
+ * @param array $list
  * @return \Closure|mixed
  * @example
  *      $spacer = \phln\collection\join(' ');
  *      $spacer([1, 2, 3]); // '1 2 3'
  */
-function join($separator = null, $list = null)
+function join(string $separator = '', array $list = [])
 {
-    return curryN(2, 𝑓join, [$separator, $list]);
+    return curryN(2, 𝑓join, func_get_args());
 }

--- a/src/collection/join.php
+++ b/src/collection/join.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\collection;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const join = '\\phln\\collection\\join';
@@ -21,7 +20,7 @@ const 𝑓join = '\\join';
  *      $spacer = \phln\collection\join(' ');
  *      $spacer([1, 2, 3]); // '1 2 3'
  */
-function join($separator = nil, $list = nil)
+function join($separator = null, $list = null)
 {
     return curryN(2, 𝑓join, [$separator, $list]);
 }

--- a/src/collection/map.php
+++ b/src/collection/map.php
@@ -12,11 +12,11 @@ const map = '\\phln\\collection\\map';
  *
  * @phlnSignature (a -> b) -> [a] -> [b]
  * @phlnCategory collection
- * @param string|callable $fn
- * @param string|array $list
+ * @param callable $fn
+ * @param array $list
  * @return \Closure|array
  */
-function map($fn = null, $list = null)
+function map(callable $fn = null, array $list = [])
 {
-    return curryN(2, '\\array_map', [$fn, $list]);
+    return curryN(2, '\\array_map', func_get_args());
 }

--- a/src/collection/map.php
+++ b/src/collection/map.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\collection;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const map = '\\phln\\collection\\map';
@@ -17,7 +16,7 @@ const map = '\\phln\\collection\\map';
  * @param string|array $list
  * @return \Closure|array
  */
-function map($fn = nil, $list = nil)
+function map($fn = null, $list = null)
 {
     return curryN(2, '\\array_map', [$fn, $list]);
 }

--- a/src/collection/mapIndexed.php
+++ b/src/collection/mapIndexed.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\collection;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const mapIndexed = '\\phln\\collection\\mapIndexed';
@@ -20,7 +19,7 @@ const 𝑓mapIndexed = '\\phln\\collection\\𝑓mapIndexed';
  * @param string|array $list
  * @return \Closure|array
  */
-function mapIndexed($fn = nil, $list = nil)
+function mapIndexed($fn = null, $list = null)
 {
     return curryN(2, 𝑓mapIndexed, [$fn, $list]);
 }

--- a/src/collection/mapIndexed.php
+++ b/src/collection/mapIndexed.php
@@ -15,13 +15,13 @@ const 𝑓mapIndexed = '\\phln\\collection\\𝑓mapIndexed';
  *
  * @phlnSignature ((a, i) -> b) -> [a] -> [b]
  * @phlnCategory collection
- * @param string|callable $fn
- * @param string|array $list
+ * @param callable $fn
+ * @param array $list
  * @return \Closure|array
  */
-function mapIndexed($fn = null, $list = null)
+function mapIndexed(callable $fn = null, array $list = [])
 {
-    return curryN(2, 𝑓mapIndexed, [$fn, $list]);
+    return curryN(2, 𝑓mapIndexed, func_get_args());
 }
 
 function 𝑓mapIndexed(callable $fn, array $list): array

--- a/src/collection/none.php
+++ b/src/collection/none.php
@@ -14,8 +14,8 @@ const 𝑓none = '\\phln\\collection\\𝑓none';
  *
  * @phlnSignature (a -> Boolean) -> [a] -> Boolean
  * @phlnCategory collection
- * @param string $predicate
- * @param string $list
+ * @param callable $predicate
+ * @param array $list
  * @return \Closure|mixed
  * @example
  *      $isEven = function ($i) {
@@ -25,9 +25,9 @@ const 𝑓none = '\\phln\\collection\\𝑓none';
  *      \phln\collection\none($isEven, [1, 3, 5]); // true
  *      \phln\collection\none($isEven, [1, 3, 5, 6]); // false
  */
-function none($predicate = null, $list = null)
+function none(callable $predicate = null, array $list = [])
 {
-    return curryN(2, 𝑓none, [$predicate, $list]);
+    return curryN(2, 𝑓none, func_get_args());
 }
 
 function 𝑓none(callable $predicate, array $list): bool

--- a/src/collection/none.php
+++ b/src/collection/none.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\collection;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 use function phln\fn\negate;
 
@@ -26,7 +25,7 @@ const 𝑓none = '\\phln\\collection\\𝑓none';
  *      \phln\collection\none($isEven, [1, 3, 5]); // true
  *      \phln\collection\none($isEven, [1, 3, 5, 6]); // false
  */
-function none($predicate = nil, $list = nil)
+function none($predicate = null, $list = null)
 {
     return curryN(2, 𝑓none, [$predicate, $list]);
 }

--- a/src/collection/nth.php
+++ b/src/collection/nth.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\collection;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const nth = '\\phln\\collection\\nth';
@@ -22,7 +21,7 @@ const 𝑓nth = '\\phln\\collection\\𝑓nth';
  *      \phln\collection\nth(1, [1, 2, 3]); // 2
  *      \phln\collection\nth(-1, [1, 2, 3]); // 3
  */
-function nth($n = nil, $list = nil)
+function nth($n = null, $list = null)
 {
     return curryN(2, 𝑓nth, [$n, $list]);
 }

--- a/src/collection/nth.php
+++ b/src/collection/nth.php
@@ -14,16 +14,16 @@ const 𝑓nth = '\\phln\\collection\\𝑓nth';
  *
  * @phlnSignature Number -> [a] -> a | Null
  * @phlnCategory collection
- * @param string $n
- * @param string $list
+ * @param integer $n
+ * @param array $list
  * @return \Closure|mixed
  * @example
  *      \phln\collection\nth(1, [1, 2, 3]); // 2
  *      \phln\collection\nth(-1, [1, 2, 3]); // 3
  */
-function nth($n = null, $list = null)
+function nth(int $n = 0, array $list = [])
 {
-    return curryN(2, 𝑓nth, [$n, $list]);
+    return curryN(2, 𝑓nth, func_get_args());
 }
 
 function 𝑓nth(int $n, array $list)

--- a/src/collection/pluck.php
+++ b/src/collection/pluck.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\collection;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 use function phln\object\prop;
 
@@ -22,7 +21,7 @@ const 𝑓pluck = '\\phln\\collection\\𝑓pluck';
  *      $list = [['a' => 1], ['a' => 2]];
  *      \phln\collection\pluck('a', $list); // [1, 2]
  */
-function pluck($key = nil, $list = nil)
+function pluck($key = null, $list = null)
 {
     return curryN(2, 𝑓pluck, [$key, $list]);
 }

--- a/src/collection/pluck.php
+++ b/src/collection/pluck.php
@@ -14,16 +14,16 @@ const 𝑓pluck = '\\phln\\collection\\𝑓pluck';
  *
  * @phlnSignature k -> [{k: v}] -> v
  * @phlnCategory collection
- * @param string $key
- * @param string|array $list
+ * @param string|integer $key
+ * @param array $list
  * @return \Closure|array
  * @example
  *      $list = [['a' => 1], ['a' => 2]];
  *      \phln\collection\pluck('a', $list); // [1, 2]
  */
-function pluck($key = null, $list = null)
+function pluck($key = '', array $list = [])
 {
-    return curryN(2, 𝑓pluck, [$key, $list]);
+    return curryN(2, 𝑓pluck, func_get_args());
 }
 
 function 𝑓pluck($key, array $list): array

--- a/src/collection/prepend.php
+++ b/src/collection/prepend.php
@@ -17,7 +17,7 @@ const 𝑓prepend = '\\phln\\collection\\𝑓prepend';
  * @phlnSignature a -> [a] -> [a]
  * @phlnSignature String -> String -> String
  * @phlnCategory collection
- * @param string $value
+ * @param mixed $value
  * @param string|array $collection
  * @return \Closure|array
  * @example
@@ -27,7 +27,7 @@ const 𝑓prepend = '\\phln\\collection\\𝑓prepend';
  */
 function prepend($value = null, $collection = null)
 {
-    return curryN(2, 𝑓prepend, [$value, $collection]);
+    return curryN(2, 𝑓prepend, func_get_args());
 }
 
 function 𝑓prepend($value, $collection)

--- a/src/collection/prepend.php
+++ b/src/collection/prepend.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\collection;
 
-use const phln\fn\nil;
 use const phln\fn\otherwise;
 use function phln\fn\curryN;
 use function phln\fn\throwException;
@@ -26,7 +25,7 @@ const 𝑓prepend = '\\phln\\collection\\𝑓prepend';
  *      \phln\collection\prepend([3], [1, 2]); // [[3], 1, 2]
  *      \phln\collection\prepend('foo', 'bar'); // [[3], 1, 2]
  */
-function prepend($value = nil, $collection = nil)
+function prepend($value = null, $collection = null)
 {
     return curryN(2, 𝑓prepend, [$value, $collection]);
 }

--- a/src/collection/range.php
+++ b/src/collection/range.php
@@ -13,15 +13,15 @@ const 𝑓range = '\\phln\\collection\\𝑓range';
  *
  * @phlnSignature Integer a => a -> a -> [a]
  * @phlnCategory collection
- * @param string|int $start
- * @param string|int $end
+ * @param int $start
+ * @param int $end
  * @return \Closure|array
  * @example
  *      \phln\collection\range(0, 3); // [0, 1, 2]
  */
-function range($start = null, $end = null)
+function range(int $start = 0, int $end = 0)
 {
-    return curryN(2, 𝑓range, [$start, $end]);
+    return curryN(2, 𝑓range, func_get_args());
 }
 
 function 𝑓range(int $from, int $to): array

--- a/src/collection/range.php
+++ b/src/collection/range.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\collection;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const range = '\\phln\\collection\\range';
@@ -20,7 +19,7 @@ const 𝑓range = '\\phln\\collection\\𝑓range';
  * @example
  *      \phln\collection\range(0, 3); // [0, 1, 2]
  */
-function range($start = nil, $end = nil)
+function range($start = null, $end = null)
 {
     return curryN(2, 𝑓range, [$start, $end]);
 }

--- a/src/collection/reduce.php
+++ b/src/collection/reduce.php
@@ -24,7 +24,7 @@ const 𝑓reduce = '\\phln\\collection\\𝑓reduce';
  *      \phln\collection\reduce(\phln\math\subtract, 0, [1, 2, 3, 4]);
  *      // ((((0 - 1) - 2) - 3) - 4) => -10
  */
-function reduce($reducer = nil, $initialValue = nil, $list = nil)
+function reduce($reducer = null, $initialValue = null, $list = null)
 {
     return curryN(3, 𝑓reduce, [$reducer, $initialValue, $list]);
 }

--- a/src/collection/reduce.php
+++ b/src/collection/reduce.php
@@ -16,17 +16,17 @@ const 𝑓reduce = '\\phln\\collection\\𝑓reduce';
  *
  * @phlnSignature ((a, b) -> a) -> a -> [b] -> a
  * @phlnCategory collection
- * @param string|callable $reducer
+ * @param callable $reducer
  * @param mixed $initialValue
- * @param string|array $list
+ * @param array $list
  * @return \Closure|mixed
  * @example
  *      \phln\collection\reduce(\phln\math\subtract, 0, [1, 2, 3, 4]);
  *      // ((((0 - 1) - 2) - 3) - 4) => -10
  */
-function reduce($reducer = null, $initialValue = null, $list = null)
+function reduce(callable $reducer = null, $initialValue = null, array $list = [])
 {
-    return curryN(3, 𝑓reduce, [$reducer, $initialValue, $list]);
+    return curryN(3, 𝑓reduce, func_get_args());
 }
 
 function 𝑓reduce(callable $reducer, $initialValue, array $list)

--- a/src/collection/reject.php
+++ b/src/collection/reject.php
@@ -14,8 +14,8 @@ const 𝑓reject = '\\phln\\collection\\𝑓reject';
  *
  * @phlnSignature (a -> Boolean) -> [a] -> [a]
  * @phlnCategory collection
- * @param string|callable $predicate
- * @param string|array $list
+ * @param callable $predicate
+ * @param array $list
  * @return \Closure|array
  * @example
  *      $isOdd = function ($i) {
@@ -23,9 +23,9 @@ const 𝑓reject = '\\phln\\collection\\𝑓reject';
  *      };
  *      \phln\collection\reject($isOdd, [1, 2, 3, 4]); // [2, 4]
  */
-function reject($predicate = null, $list = null)
+function reject(callable $predicate = null, array $list = [])
 {
-    return curryN(2, 𝑓reject, [$predicate, $list]);
+    return curryN(2, 𝑓reject, func_get_args());
 }
 
 function 𝑓reject(callable $predicate, array $list): array

--- a/src/collection/reject.php
+++ b/src/collection/reject.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\collection;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 use function phln\fn\negate;
 
@@ -24,7 +23,7 @@ const 𝑓reject = '\\phln\\collection\\𝑓reject';
  *      };
  *      \phln\collection\reject($isOdd, [1, 2, 3, 4]); // [2, 4]
  */
-function reject($predicate = nil, $list = nil)
+function reject($predicate = null, $list = null)
 {
     return curryN(2, 𝑓reject, [$predicate, $list]);
 }

--- a/src/collection/slice.php
+++ b/src/collection/slice.php
@@ -20,8 +20,8 @@ const 𝑓slice = '\\phln\\collection\\𝑓slice';
  * @phlnSignature Integer -> Integer -> [a] -> [a]
  * @phlnSignature Integer -> Integer -> String -> String
  * @phlnCategory collection
- * @param string|integer $offset
- * @param string|integer $length
+ * @param integer $offset
+ * @param integer $length
  * @param string|array $collection
  * @return \Closure|array|string
  * @see \array_slice()
@@ -30,9 +30,9 @@ const 𝑓slice = '\\phln\\collection\\𝑓slice';
  *      $takeTwo = \phln\collection\slice(0, 2);
  *      $takeTwo([1, 2, 3]); // [1, 2]
  */
-function slice($offset = null, $length = null, $collection = null)
+function slice(int $offset = 0, int $length = 0, $collection = null)
 {
-    return curryN(3, 𝑓slice, [$offset, $length, $collection]);
+    return curryN(3, 𝑓slice, func_get_args());
 }
 
 function 𝑓slice(int $offset, int $length, $collection)

--- a/src/collection/slice.php
+++ b/src/collection/slice.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace phln\collection;
 
 use const phln\fn\{
-    __, nil, otherwise
+    __, otherwise
 };
 use function phln\fn\{
     curryN, partial, throwException
@@ -30,7 +30,7 @@ const 𝑓slice = '\\phln\\collection\\𝑓slice';
  *      $takeTwo = \phln\collection\slice(0, 2);
  *      $takeTwo([1, 2, 3]); // [1, 2]
  */
-function slice($offset = nil, $length = nil, $collection = nil)
+function slice($offset = null, $length = null, $collection = null)
 {
     return curryN(3, 𝑓slice, [$offset, $length, $collection]);
 }

--- a/src/collection/sort.php
+++ b/src/collection/sort.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\collection;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const sort = '\\phln\\collection\\sort';
@@ -25,7 +24,7 @@ const 𝑓sort = '\\phln\\collection\\𝑓sort';
  *
  *      \phln\collection\sort($diff, [3, 2, 1]); // [1, 2, 3]
  */
-function sort($comparator = nil, $list = nil)
+function sort($comparator = null, $list = null)
 {
     return curryN(2, 𝑓sort, [$comparator, $list]);
 }

--- a/src/collection/sort.php
+++ b/src/collection/sort.php
@@ -13,8 +13,8 @@ const 𝑓sort = '\\phln\\collection\\𝑓sort';
  *
  * @phlnSignature ((a, a) -> Number) -> [a] -> [a]
  * @phlnCategory collection
- * @param string|callable $comparator
- * @param string|array $list
+ * @param callable $comparator
+ * @param array $list
  * @return \Closure|array
  * @see \usort()
  * @example
@@ -24,9 +24,9 @@ const 𝑓sort = '\\phln\\collection\\𝑓sort';
  *
  *      \phln\collection\sort($diff, [3, 2, 1]); // [1, 2, 3]
  */
-function sort($comparator = null, $list = null)
+function sort(callable $comparator = null, array $list = [])
 {
-    return curryN(2, 𝑓sort, [$comparator, $list]);
+    return curryN(2, 𝑓sort, func_get_args());
 }
 
 function 𝑓sort(callable $comparator, array $list): array

--- a/src/collection/sortBy.php
+++ b/src/collection/sortBy.php
@@ -13,8 +13,8 @@ const 𝑓sortBy = '\\phln\\collection\\𝑓sortBy';
  *
  * @phlnSignature (a -> b) -> [a] -> [a]
  * @phlnCategory collection
- * @param string|callable $mapper
- * @param string|array $list
+ * @param callable $mapper
+ * @param array $list
  * @return \Closure|array
  * @see \array_multisort()
  * @example
@@ -25,9 +25,9 @@ const 𝑓sortBy = '\\phln\\collection\\𝑓sortBy';
  *
  *      \phln\collection\soryBy(\phln\object\prop('name'), $people); // [$alice, $bob, $clara]
  */
-function sortBy($mapper = null, $list = null)
+function sortBy(callable $mapper = null, array $list = [])
 {
-    return curryN(2, 𝑓sortBy, [$mapper, $list]);
+    return curryN(2, 𝑓sortBy, func_get_args());
 }
 
 function 𝑓sortBy(callable $mapper, array $list): array

--- a/src/collection/sortBy.php
+++ b/src/collection/sortBy.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\collection;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const sortBy = '\\phln\\collection\\sortBy';
@@ -26,7 +25,7 @@ const 𝑓sortBy = '\\phln\\collection\\𝑓sortBy';
  *
  *      \phln\collection\soryBy(\phln\object\prop('name'), $people); // [$alice, $bob, $clara]
  */
-function sortBy($mapper = nil, $list = nil)
+function sortBy($mapper = null, $list = null)
 {
     return curryN(2, 𝑓sortBy, [$mapper, $list]);
 }

--- a/src/fn/apply.php
+++ b/src/fn/apply.php
@@ -17,7 +17,7 @@ const 𝑓apply = '\\phln\\fn\\𝑓apply';
  * @example
  *      \phln\fn\apply(\phln\math\sum, [1, 2]); // 3
  */
-function apply($fn = nil, $arguments = nil)
+function apply($fn = null, $arguments = null)
 {
     return curryN(2, 𝑓apply, [$fn, $arguments]);
 }

--- a/src/fn/apply.php
+++ b/src/fn/apply.php
@@ -11,15 +11,15 @@ const 𝑓apply = '\\phln\\fn\\𝑓apply';
  *
  * @phlnSignature (*... -> a) -> [*] -> a
  * @phlnCategory function
- * @param string|callable $fn
- * @param string|array $arguments
+ * @param callable $fn
+ * @param array $arguments
  * @return \Closure|mixed
  * @example
  *      \phln\fn\apply(\phln\math\sum, [1, 2]); // 3
  */
-function apply($fn = null, $arguments = null)
+function apply(callable $fn = null, array $arguments = [])
 {
-    return curryN(2, 𝑓apply, [$fn, $arguments]);
+    return curryN(2, 𝑓apply, func_get_args());
 }
 
 function 𝑓apply(callable $fn, array $arguments)

--- a/src/fn/curry.php
+++ b/src/fn/curry.php
@@ -5,8 +5,6 @@ namespace phln\fn;
 
 const curry = '\\phln\\fn\\curry';
 
-const nil = '_phln_nil_argument';
-
 /**
  * Returns a curried equivalent of the provided function.
  *

--- a/src/fn/curryN.php
+++ b/src/fn/curryN.php
@@ -24,10 +24,6 @@ const curryN = '\\phln\\fn\\curryN';
  */
 function curryN(int $n, callable $fn, array $args = [])
 {
-    $args = array_filter($args, function ($value) {
-        return $value !== null;
-    });
-
     $argumentsLengthMatch = function (array $arguments) use ($n) {
         return count($arguments) >= $n;
     };

--- a/src/fn/curryN.php
+++ b/src/fn/curryN.php
@@ -25,7 +25,7 @@ const curryN = '\\phln\\fn\\curryN';
 function curryN(int $n, callable $fn, array $args = [])
 {
     $args = array_filter($args, function ($value) {
-        return $value !== nil;
+        return $value !== null;
     });
 
     $argumentsLengthMatch = function (array $arguments) use ($n) {

--- a/src/fn/partial.php
+++ b/src/fn/partial.php
@@ -16,16 +16,16 @@ const 𝑓partial = '\\phln\\fn\\𝑓partial';
  *
  * @phlnSignature ((a, b, c, ..., n) -> x) -> [a, b, c, ...] -> ((d, e, f, ..., n) -> x)
  * @phlnCategory function
- * @param string|callable $fn
- * @param string|array ...$args
+ * @param callable $fn
+ * @param array $args
  * @return \Closure
  * @example
- *      $subtractFive = \phln\fn\partial(\phln\math\subtract, \phln\fn\__, 5);
+ *      $subtractFive = \phln\fn\partial(\phln\math\subtract, [\phln\fn\__, 5]);
  *      $subtractFive(10); // 5
  */
-function partial($fn = null, $args = null): \Closure
+function partial(callable $fn = null, array $args = []): \Closure
 {
-    return curryN(2, 𝑓partial, [$fn, $args]);
+    return curryN(2, 𝑓partial, func_get_args());
 }
 
 function 𝑓partial(callable $fn, array $args): \Closure

--- a/src/fn/partial.php
+++ b/src/fn/partial.php
@@ -23,7 +23,7 @@ const 𝑓partial = '\\phln\\fn\\𝑓partial';
  *      $subtractFive = \phln\fn\partial(\phln\math\subtract, \phln\fn\__, 5);
  *      $subtractFive(10); // 5
  */
-function partial($fn = nil, $args = nil): \Closure
+function partial($fn = null, $args = null): \Closure
 {
     return curryN(2, 𝑓partial, [$fn, $args]);
 }

--- a/src/fn/tap.php
+++ b/src/fn/tap.php
@@ -18,7 +18,7 @@ const 𝑓tap = '\\phln\\fn\\𝑓tap';
  *      $dump = \phln\fn\tap('var_dump');
  *      $dump('foo'); // var_dumps('foo'); returns 'foo'
  */
-function tap($fn = nil, $value = nil)
+function tap($fn = null, $value = null)
 {
     return curryN(2, 𝑓tap, [$fn, $value]);
 }

--- a/src/fn/tap.php
+++ b/src/fn/tap.php
@@ -18,9 +18,9 @@ const 𝑓tap = '\\phln\\fn\\𝑓tap';
  *      $dump = \phln\fn\tap('var_dump');
  *      $dump('foo'); // var_dumps('foo'); returns 'foo'
  */
-function tap($fn = null, $value = null)
+function tap(callable $fn = null, $value = null)
 {
-    return curryN(2, 𝑓tap, [$fn, $value]);
+    return curryN(2, 𝑓tap, func_get_args());
 }
 
 function 𝑓tap(callable $fn, $value)

--- a/src/fn/throwException.php
+++ b/src/fn/throwException.php
@@ -3,8 +3,6 @@ declare(strict_types=1);
 
 namespace phln\fn;
 
-use function phln\fn\curryN;
-
 const throwException = '\\phln\\fn\\throwException';
 
 /**

--- a/src/fn/throwException.php
+++ b/src/fn/throwException.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace phln\fn;
 
 use function phln\fn\curryN;
-use const phln\fn\nil;
 
 const throwException = '\\phln\\fn\\throwException';
 

--- a/src/fn/unapply.php
+++ b/src/fn/unapply.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace phln\fn;
 
 use function phln\fn\curryN;
-use const phln\fn\nil;
 
 const unapply = '\\phln\\fn\\unapply';
 const 𝑓unapply = '\\phln\\fn\\𝑓unapply';
@@ -24,7 +23,7 @@ const 𝑓unapply = '\\phln\\fn\\𝑓unapply';
  * @example
  *      \phln\fn\unapply('\\json_encode')(1, 2, 3); // [1,2,3]
  */
-function unapply($fn = nil, ...$args)
+function unapply($fn = null, ...$args)
 {
     return curryN(2, 𝑓unapply, array_merge([$fn], $args));
 }

--- a/src/fn/unapply.php
+++ b/src/fn/unapply.php
@@ -23,9 +23,9 @@ const 𝑓unapply = '\\phln\\fn\\𝑓unapply';
  * @example
  *      \phln\fn\unapply('\\json_encode')(1, 2, 3); // [1,2,3]
  */
-function unapply($fn = null, ...$args)
+function unapply(callable $fn = null, ...$args)
 {
-    return curryN(2, 𝑓unapply, array_merge([$fn], $args));
+    return curryN(2, 𝑓unapply, func_get_args());
 }
 
 function 𝑓unapply(callable $fn, ...$args)

--- a/src/logic/allPass.php
+++ b/src/logic/allPass.php
@@ -39,7 +39,7 @@ function allPass(array $predicates): callable
             function ($carry, callable $p) use ($values) {
                 return (false === $carry) ? false : $p(...$values);
             },
-            null,
+            true,
             $predicates
         );
     });

--- a/src/logic/both.php
+++ b/src/logic/both.php
@@ -35,7 +35,7 @@ const 𝑓both = '\\phln\\logic\\𝑓both';
  */
 function both($left = null, $right = null)
 {
-    return curryN(2, 𝑓both, [$left, $right]);
+    return curryN(2, 𝑓both, func_get_args());
 }
 
 function 𝑓both($left, $right)

--- a/src/logic/both.php
+++ b/src/logic/both.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\logic;
 
-use const phln\fn\nil;
 use const phln\fn\otherwise;
 use function phln\collection\all;
 use function phln\fn\{
@@ -34,7 +33,7 @@ const 𝑓both = '\\phln\\logic\\𝑓both';
  *      $f(12); // true
  *      \phln\logic\both(true, false); // false
  */
-function both($left = nil, $right = nil)
+function both($left = null, $right = null)
 {
     return curryN(2, 𝑓both, [$left, $right]);
 }

--- a/src/logic/defaultTo.php
+++ b/src/logic/defaultTo.php
@@ -22,7 +22,7 @@ const 𝑓defaultTo = '\\phln\\logic\\𝑓defaultTo';
  */
 function defaultTo($default = null, $value = null)
 {
-    return curryN(2, 𝑓defaultTo, [$default, $value]);
+    return curryN(2, 𝑓defaultTo, func_get_args());
 }
 
 function 𝑓defaultTo($default, $value)

--- a/src/logic/defaultTo.php
+++ b/src/logic/defaultTo.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\logic;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const defaultTo = '\\phln\\logic\\defaultTo';
@@ -21,7 +20,7 @@ const 𝑓defaultTo = '\\phln\\logic\\𝑓defaultTo';
  *      \phln\logic\defaultTo(42, null); // 42
  *      \phln\logic\defaultTo(42, 'life'); // 'life'
  */
-function defaultTo($default = nil, $value = nil)
+function defaultTo($default = null, $value = null)
 {
     return curryN(2, 𝑓defaultTo, [$default, $value]);
 }

--- a/src/logic/either.php
+++ b/src/logic/either.php
@@ -37,7 +37,7 @@ const 𝑓either = '\\phln\\logic\\𝑓either';
  */
 function either($left = null, $right = null)
 {
-    return curryN(2, 𝑓either, [$left, $right]);
+    return curryN(2, 𝑓either, func_get_args());
 }
 
 function 𝑓either($left, $right)

--- a/src/logic/either.php
+++ b/src/logic/either.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\logic;
 
-use const phln\fn\nil;
 use const phln\fn\otherwise;
 use function phln\collection\all;
 use function phln\fn\{
@@ -36,7 +35,7 @@ const 𝑓either = '\\phln\\logic\\𝑓either';
  *      $f(21); // true
  *      \phln\login\either(true, false); // true
  */
-function either($left = nil, $right = nil)
+function either($left = null, $right = null)
 {
     return curryN(2, 𝑓either, [$left, $right]);
 }

--- a/src/logic/ifElse.php
+++ b/src/logic/ifElse.php
@@ -29,7 +29,7 @@ const 𝑓ifElse = '\\phln\\logic\\𝑓ifElse';
  *      $fizzbuzz(15); // 'fizzbuzz'
  *      $fizzbuzz(1); // 1
  */
-function ifElse($predicate = nil, $onTrue = nil, $onFalse = nil): \Closure
+function ifElse($predicate = null, $onTrue = null, $onFalse = null): \Closure
 {
     return curryN(3, 𝑓ifElse, [$predicate, $onTrue, $onFalse]);
 }

--- a/src/logic/ifElse.php
+++ b/src/logic/ifElse.php
@@ -14,9 +14,9 @@ const 𝑓ifElse = '\\phln\\logic\\𝑓ifElse';
  *
  * @phlnSignature (*... -> Boolean) -> (*... -> *) -> (*... -> *) -> (*... -> *)
  * @phlnCategory logic
- * @param string|callable $predicate
- * @param string|callable $onTrue
- * @param string|callable $onFalse
+ * @param callable $predicate
+ * @param callable $onTrue
+ * @param callable $onFalse
  * @return \Closure
  * @example
  *      $modulo15 = \phln\fn\swap(\phln\math\modulo)(15);
@@ -29,9 +29,9 @@ const 𝑓ifElse = '\\phln\\logic\\𝑓ifElse';
  *      $fizzbuzz(15); // 'fizzbuzz'
  *      $fizzbuzz(1); // 1
  */
-function ifElse($predicate = null, $onTrue = null, $onFalse = null): \Closure
+function ifElse(callable $predicate = null, callable $onTrue = null, callable $onFalse = null): \Closure
 {
-    return curryN(3, 𝑓ifElse, [$predicate, $onTrue, $onFalse]);
+    return curryN(3, 𝑓ifElse, func_get_args());
 }
 
 function 𝑓ifElse(callable $predicate, callable $onTrue, callable $onFalse): \Closure

--- a/src/math/add.php
+++ b/src/math/add.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\math;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const add = '\\phln\\math\\add';
@@ -18,7 +17,7 @@ const 𝑓add = '\\phln\\math\\𝑓add';
  * @param mixed $b
  * @return \Closure|mixed
  */
-function add($a = nil, $b = nil)
+function add($a = null, $b = null)
 {
     return curryN(2, 𝑓add, [$a, $b]);
 }

--- a/src/math/add.php
+++ b/src/math/add.php
@@ -19,7 +19,7 @@ const 𝑓add = '\\phln\\math\\𝑓add';
  */
 function add($a = null, $b = null)
 {
-    return curryN(2, 𝑓add, [$a, $b]);
+    return curryN(2, 𝑓add, func_get_args());
 }
 
 function 𝑓add($a, $b)

--- a/src/math/divide.php
+++ b/src/math/divide.php
@@ -19,7 +19,7 @@ const 𝑓divide = '\\phln\\math\\𝑓divide';
  */
 function divide($a = null, $b = null)
 {
-    return curryN(2, 𝑓divide, [$a, $b]);
+    return curryN(2, 𝑓divide, func_get_args());
 }
 
 function 𝑓divide($a, $b)

--- a/src/math/divide.php
+++ b/src/math/divide.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\math;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const divide = '\\phln\\math\\divide';
@@ -18,7 +17,7 @@ const 𝑓divide = '\\phln\\math\\𝑓divide';
  * @param mixed $b
  * @return \Closure|mixed
  */
-function divide($a = nil, $b = nil)
+function divide($a = null, $b = null)
 {
     return curryN(2, 𝑓divide, [$a, $b]);
 }

--- a/src/math/modulo.php
+++ b/src/math/modulo.php
@@ -21,7 +21,7 @@ const 𝑓modulo = '\\phln\\math\\𝑓modulo';
  */
 function modulo($a = null, $b = null)
 {
-    return curryN(2, 𝑓modulo, [$a, $b]);
+    return curryN(2, 𝑓modulo, func_get_args());
 }
 
 function 𝑓modulo($a, $b)

--- a/src/math/modulo.php
+++ b/src/math/modulo.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\math;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const modulo = '\\phln\\math\\modulo';
@@ -20,7 +19,7 @@ const 𝑓modulo = '\\phln\\math\\𝑓modulo';
  * @example
  *      \\phln\\math\\modulo(1, 2) // 1
  */
-function modulo($a = nil, $b = nil)
+function modulo($a = null, $b = null)
 {
     return curryN(2, 𝑓modulo, [$a, $b]);
 }

--- a/src/math/multiply.php
+++ b/src/math/multiply.php
@@ -22,7 +22,7 @@ const 𝑓multiply = '\\phln\\math\\𝑓multiply';
  */
 function multiply($a = null, $b = null)
 {
-    return curryN(2, 𝑓multiply, [$a, $b]);
+    return curryN(2, 𝑓multiply, func_get_args());
 }
 
 function 𝑓multiply($a, $b)

--- a/src/math/multiply.php
+++ b/src/math/multiply.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\math;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const multiply = '\\phln\\math\\multiply';
@@ -21,7 +20,7 @@ const 𝑓multiply = '\\phln\\math\\𝑓multiply';
  *      $triple = \phln\math\multiply(3);
  *      $triple(7); // 21
  */
-function multiply($a = nil, $b = nil)
+function multiply($a = null, $b = null)
 {
     return curryN(2, 𝑓multiply, [$a, $b]);
 }

--- a/src/math/subtract.php
+++ b/src/math/subtract.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\math;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const subtract = '\\phln\\math\\subtract';
@@ -21,7 +20,7 @@ const 𝑓subtract = '\\phln\\math\\𝑓subtract';
  *      $complementaryAngle = \phln\math\subtract(90);
  *      $complementaryAngle(30); //=> 60
  */
-function subtract($a = nil, $b = nil)
+function subtract($a = null, $b = null)
 {
     return curryN(2, 𝑓subtract, [$a, $b]);
 }

--- a/src/math/subtract.php
+++ b/src/math/subtract.php
@@ -13,8 +13,8 @@ const 𝑓subtract = '\\phln\\math\\𝑓subtract';
  *
  * @phlnSignature Number a => a -> a -> a
  * @phlnCategory math
- * @param string $a
- * @param string $b
+ * @param number $a
+ * @param number $b
  * @return \Closure|mixed
  * @example
  *      $complementaryAngle = \phln\math\subtract(90);
@@ -22,7 +22,7 @@ const 𝑓subtract = '\\phln\\math\\𝑓subtract';
  */
 function subtract($a = null, $b = null)
 {
-    return curryN(2, 𝑓subtract, [$a, $b]);
+    return curryN(2, 𝑓subtract, func_get_args());
 }
 
 function 𝑓subtract($a, $b)

--- a/src/object/eqProps.php
+++ b/src/object/eqProps.php
@@ -19,15 +19,15 @@ const 𝑓eqProps = '\\phln\\object\\𝑓eqProps';
  * @phlnSignature k -> {k: v} -> {k: v} -> Boolean
  * @phlnCategory object
  * @param string $prop
- * @param string $a
- * @param string $b
+ * @param array $a
+ * @param array $b
  * @return \Closure|mixed
  * @example
  *      \phln\object\eqProps('name', ['name' => 'Jon'], ['name' => 'Jon']); // true
  */
-function eqProps($prop = null, $a = null, $b = null)
+function eqProps(string $prop = '', array $a = [], array $b = [])
 {
-    return curryN(3, 𝑓eqProps, [$prop, $a, $b]);
+    return curryN(3, 𝑓eqProps, func_get_args());
 }
 
 function 𝑓eqProps(string $prop, array $a, array $b): bool

--- a/src/object/eqProps.php
+++ b/src/object/eqProps.php
@@ -25,7 +25,7 @@ const 𝑓eqProps = '\\phln\\object\\𝑓eqProps';
  * @example
  *      \phln\object\eqProps('name', ['name' => 'Jon'], ['name' => 'Jon']); // true
  */
-function eqProps($prop = nil, $a = nil, $b = nil)
+function eqProps($prop = null, $a = null, $b = null)
 {
     return curryN(3, 𝑓eqProps, [$prop, $a, $b]);
 }

--- a/src/object/merge.php
+++ b/src/object/merge.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\object;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const merge = '\\phln\\object\\merge';
@@ -21,7 +20,7 @@ const 𝑓merge = '\\phln\\object\\𝑓merge';
  *      $toDefaults = \phln\fn\partial(\phln\object\merge, [\phln\fn\__, ['x' => 0]);
  *      $toDefaults(['x' => 2, 'y' => 1]); // ['x' => 0, 'y' => 1]
  */
-function merge($left = nil, $right = nil)
+function merge($left = null, $right = null)
 {
     return curryN(2, 𝑓merge, [$left, $right]);
 }

--- a/src/object/merge.php
+++ b/src/object/merge.php
@@ -13,16 +13,16 @@ const 𝑓merge = '\\phln\\object\\𝑓merge';
  *
  * @phlnSignature {k: v} -> {k: v} -> {k: v}
  * @phlnCategory object
- * @param string|array $left
- * @param string|array $right
+ * @param array $left
+ * @param array $right
  * @return \Closure|array
  * @example
  *      $toDefaults = \phln\fn\partial(\phln\object\merge, [\phln\fn\__, ['x' => 0]);
  *      $toDefaults(['x' => 2, 'y' => 1]); // ['x' => 0, 'y' => 1]
  */
-function merge($left = null, $right = null)
+function merge(array $left = [], array $right = [])
 {
-    return curryN(2, 𝑓merge, [$left, $right]);
+    return curryN(2, 𝑓merge, func_get_args());
 }
 
 function 𝑓merge(array $left, array $right): array

--- a/src/object/omit.php
+++ b/src/object/omit.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\object;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const omit = '\\phln\\object\\omit';
@@ -20,7 +19,7 @@ const 𝑓omit = '\\phln\\object\\𝑓omit';
  * @example
  *      \phln\object\omit(['a', 'c'], ['a' => 1, 'b' => 2, 'c' => 3]); // ['b' => 2]
  */
-function omit($omitKeys = nil, $object = nil)
+function omit($omitKeys = null, $object = null)
 {
     return curryN(2, 𝑓omit, [$omitKeys, $object]);
 }

--- a/src/object/omit.php
+++ b/src/object/omit.php
@@ -13,15 +13,15 @@ const 𝑓omit = '\\phln\\object\\𝑓omit';
  *
  * @phlnSignature [String] -> {String: *} -> {String: *}
  * @phlnCategory object
- * @param string $omitKeys
- * @param string $object
+ * @param array $omitKeys
+ * @param array $object
  * @return \Closure|mixed
  * @example
  *      \phln\object\omit(['a', 'c'], ['a' => 1, 'b' => 2, 'c' => 3]); // ['b' => 2]
  */
-function omit($omitKeys = null, $object = null)
+function omit(array $omitKeys = [], array $object = [])
 {
-    return curryN(2, 𝑓omit, [$omitKeys, $object]);
+    return curryN(2, 𝑓omit, func_get_args());
 }
 
 function 𝑓omit(array $omitKeys, array $object): array

--- a/src/object/path.php
+++ b/src/object/path.php
@@ -16,15 +16,15 @@ const 𝑓path = '\\phln\\object\\𝑓path';
  * @phlnSignature String -> {k: v} -> v|Null
  * @phlnCategory object
  * @param string $path
- * @param string|array $object
+ * @param array $object
  * @return \Closure|mixed
  * @example
  *      \phln\object\path('a.b', ['a' => ['b' => 'foo']]); // 'foo'
  *      \phln\object\path('a.b.c', ['a' => ['b' => 'foo']]); // null
  */
-function path($path = null, $object = null)
+function path(string $path = '', array $object = [])
 {
-    return curryN(2, 𝑓path, [$path, $object]);
+    return curryN(2, 𝑓path, func_get_args());
 }
 
 function 𝑓path(string $path, array $object)

--- a/src/object/path.php
+++ b/src/object/path.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\object;
 
-use const phln\fn\nil;
 use function phln\collection\reduce;
 use function phln\collection\tail;
 use function phln\fn\curryN;
@@ -23,7 +22,7 @@ const 𝑓path = '\\phln\\object\\𝑓path';
  *      \phln\object\path('a.b', ['a' => ['b' => 'foo']]); // 'foo'
  *      \phln\object\path('a.b.c', ['a' => ['b' => 'foo']]); // null
  */
-function path($path = nil, $object = nil)
+function path($path = null, $object = null)
 {
     return curryN(2, 𝑓path, [$path, $object]);
 }

--- a/src/object/pathOr.php
+++ b/src/object/pathOr.php
@@ -14,8 +14,8 @@ const 𝑓pathOr = '\\phln\\object\\𝑓pathOr';
  * @phlnSignature String -> a -> {k: v} -> v | a
  * @phlnCategory object
  * @param string $path
- * @param string $default
- * @param string|array $object
+ * @param mixed $default
+ * @param array $object
  * @return \Closure|mixed
  * @example
  *      \phln\object\pathOr('a.b', 'foo', ['a' => ['b' => 1]]); // 1
@@ -23,9 +23,9 @@ const 𝑓pathOr = '\\phln\\object\\𝑓pathOr';
  *      \phln\object\pathOr('a.b', 'foo', ['a' => ['b' => null]]); // 'foo'
  *      \phln\object\pathOr('a.b', 'foo', ['a' => 1]); // 'foo'
  */
-function pathOr($path = null, $default = null, $object = null)
+function pathOr(string $path = '', $default = null, array $object = [])
 {
-    return curryN(3, 𝑓pathOr, [$path, $default, $object]);
+    return curryN(3, 𝑓pathOr, func_get_args());
 }
 
 function 𝑓pathOr(string $path, $default, array $object)

--- a/src/object/pathOr.php
+++ b/src/object/pathOr.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\object;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const pathOr = '\\phln\\object\\pathOr';
@@ -24,7 +23,7 @@ const 𝑓pathOr = '\\phln\\object\\𝑓pathOr';
  *      \phln\object\pathOr('a.b', 'foo', ['a' => ['b' => null]]); // 'foo'
  *      \phln\object\pathOr('a.b', 'foo', ['a' => 1]); // 'foo'
  */
-function pathOr($path = nil, $default = nil, $object = nil)
+function pathOr($path = null, $default = null, $object = null)
 {
     return curryN(3, 𝑓pathOr, [$path, $default, $object]);
 }

--- a/src/object/pick.php
+++ b/src/object/pick.php
@@ -13,15 +13,15 @@ const 𝑓pick = '\\phln\\object\\𝑓pick';
  *
  * @phlnSignature [String] -> {String: *} -> {String: *}
  * @phlnCategory object
- * @param string|array $useKeys
- * @param string|array $object
+ * @param array $useKeys
+ * @param array $object
  * @return \Closure|array
  * @example
  *      \phln\object\pick(['a'], ['a' => 1, 'b' => 2]); // ['a' => 1]
  */
-function pick($useKeys = null, $object = null)
+function pick(array $useKeys = [], array $object = [])
 {
-    return curryN(2, 𝑓pick, [$useKeys, $object]);
+    return curryN(2, 𝑓pick, func_get_args());
 }
 
 function 𝑓pick(array $useKeys, array $object): array

--- a/src/object/pick.php
+++ b/src/object/pick.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\object;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const pick = '\\phln\\object\\pick';
@@ -20,7 +19,7 @@ const 𝑓pick = '\\phln\\object\\𝑓pick';
  * @example
  *      \phln\object\pick(['a'], ['a' => 1, 'b' => 2]); // ['a' => 1]
  */
-function pick($useKeys = nil, $object = nil)
+function pick($useKeys = null, $object = null)
 {
     return curryN(2, 𝑓pick, [$useKeys, $object]);
 }

--- a/src/object/prop.php
+++ b/src/object/prop.php
@@ -13,13 +13,13 @@ const 𝑓prop = '\\phln\\object\\𝑓prop';
  *
  * @phlnSignature k -> {k: v} -> v
  * @phlnCategory object
- * @param string $key
- * @param string|array $array
+ * @param string|integer $key
+ * @param array $array
  * @return \Closure|mixed
  */
-function prop($key = null, $array = null)
+function prop($key = '', array $array = [])
 {
-    return curryN(2, 𝑓prop, [$key, $array]);
+    return curryN(2, 𝑓prop, func_get_args());
 }
 
 function 𝑓prop($key, array $array)

--- a/src/object/prop.php
+++ b/src/object/prop.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\object;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const prop = '\\phln\\object\\prop';
@@ -18,7 +17,7 @@ const 𝑓prop = '\\phln\\object\\𝑓prop';
  * @param string|array $array
  * @return \Closure|mixed
  */
-function prop($key = nil, $array = nil)
+function prop($key = null, $array = null)
 {
     return curryN(2, 𝑓prop, [$key, $array]);
 }

--- a/src/object/props.php
+++ b/src/object/props.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace phln\object;
 
 use const phln\fn\__;
-use const phln\fn\nil;
 use function phln\collection\append;
 use function phln\collection\reduce;
 use function phln\fn\curryN;
@@ -25,7 +24,7 @@ const 𝑓props = '\\phln\\object\\𝑓props';
  *      $fullName = \phln\fn\compose(\phln\string\join(' '), \phln\object\props(['firstName', 'lastName']));
  *      $fullName(['lastName' => 'Snow', 'firstName' => 'Jon']); // 'Jon Snow'
  */
-function props($props = nil, $object = nil)
+function props($props = null, $object = null)
 {
     return curryN(2, 𝑓props, [$props, $object]);
 }

--- a/src/object/props.php
+++ b/src/object/props.php
@@ -17,16 +17,16 @@ const 𝑓props = '\\phln\\object\\𝑓props';
  *
  * @phlnSignature [k] -> {k: v} -> [v]
  * @phlnCategory object
- * @param string|array $props
- * @param string|array $object
+ * @param array $props
+ * @param array $object
  * @return \Closure|array
  * @example
  *      $fullName = \phln\fn\compose(\phln\string\join(' '), \phln\object\props(['firstName', 'lastName']));
  *      $fullName(['lastName' => 'Snow', 'firstName' => 'Jon']); // 'Jon Snow'
  */
-function props($props = null, $object = null)
+function props(array $props = [], array $object = [])
 {
-    return curryN(2, 𝑓props, [$props, $object]);
+    return curryN(2, 𝑓props, func_get_args());
 }
 
 function 𝑓props(array $props, array $object): array

--- a/src/object/where.php
+++ b/src/object/where.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\object;
 
-use const phln\fn\nil;
 use function phln\collection\all;
 use function phln\fn\curryN;
 
@@ -28,7 +27,7 @@ const 𝑓where = '\\phln\\object\\𝑓where';
  *
  *      $verifyJon(['firstName' => 'Jon', 'lastName' => 'Snow', 'house' => 'Stark']); // true
  */
-function where($predicates = nil, $object = nil)
+function where($predicates = null, $object = null)
 {
     return curryN(2, 𝑓where, [$predicates, $object]);
 }

--- a/src/object/where.php
+++ b/src/object/where.php
@@ -16,8 +16,8 @@ const 𝑓where = '\\phln\\object\\𝑓where';
  *
  * @phlnSignature {String: (* -> Boolean)} -> {String: *} -> Boolean
  * @phlnCategory object
- * @param string|array $predicates
- * @param string|array $object
+ * @param array $predicates
+ * @param array $object
  * @return \Closure|bool
  * @example
  *      $verifyJon = \phln\object\where([
@@ -27,9 +27,9 @@ const 𝑓where = '\\phln\\object\\𝑓where';
  *
  *      $verifyJon(['firstName' => 'Jon', 'lastName' => 'Snow', 'house' => 'Stark']); // true
  */
-function where($predicates = null, $object = null)
+function where(array $predicates = [], array $object = [])
 {
-    return curryN(2, 𝑓where, [$predicates, $object]);
+    return curryN(2, 𝑓where, func_get_args());
 }
 
 function 𝑓where(array $predicates, array $object): bool

--- a/src/object/whereEq.php
+++ b/src/object/whereEq.php
@@ -15,16 +15,16 @@ const 𝑓whereEq = '\\phln\\object\\𝑓whereEq';
  *
  * @phlnSignature {String: *} -> {String: *} -> Boolean
  * @phlnCategory object
- * @param string $predicates
- * @param string $object
+ * @param array $predicates
+ * @param array $object
  * @return \Closure|bool
  * @example
  *      $verifyJon = \phln\object\whereEq(['firstName' => 'Jon', 'lastName' => 'Snow']);
  *      $verifyJon(['firstName' => 'Jon', 'lastName' => 'Snow']); // true
  */
-function whereEq($predicates = null, $object = null)
+function whereEq(array $predicates = [], array $object = [])
 {
-    return curryN(2, 𝑓whereEq, [$predicates, $object]);
+    return curryN(2, 𝑓whereEq, func_get_args());
 }
 
 function 𝑓whereEq(array $predicates, array $object): bool

--- a/src/object/whereEq.php
+++ b/src/object/whereEq.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\object;
 
-use const phln\fn\nil;
 use const phln\relation\equals;
 use function phln\collection\map;
 use function phln\fn\curryN;
@@ -23,7 +22,7 @@ const 𝑓whereEq = '\\phln\\object\\𝑓whereEq';
  *      $verifyJon = \phln\object\whereEq(['firstName' => 'Jon', 'lastName' => 'Snow']);
  *      $verifyJon(['firstName' => 'Jon', 'lastName' => 'Snow']); // true
  */
-function whereEq($predicates = nil, $object = nil)
+function whereEq($predicates = null, $object = null)
 {
     return curryN(2, 𝑓whereEq, [$predicates, $object]);
 }

--- a/src/relation/clamp.php
+++ b/src/relation/clamp.php
@@ -24,7 +24,7 @@ const 𝑓clamp = '\\phln\\relation\\𝑓clamp';
  *      \phln\relation\clamp(-1, 1, 100); // 1
  *      \phln\relation\clamp(-1, 1, 0); // 0
  */
-function clamp($min = nil, $max = nil, $value = nil)
+function clamp($min = null, $max = null, $value = null)
 {
     return curryN(3, 𝑓clamp, [$min, $max, $value]);
 }

--- a/src/relation/clamp.php
+++ b/src/relation/clamp.php
@@ -26,7 +26,7 @@ const 𝑓clamp = '\\phln\\relation\\𝑓clamp';
  */
 function clamp($min = null, $max = null, $value = null)
 {
-    return curryN(3, 𝑓clamp, [$min, $max, $value]);
+    return curryN(3, 𝑓clamp, func_get_args());
 }
 
 function 𝑓clamp($min, $max, $value)

--- a/src/relation/difference.php
+++ b/src/relation/difference.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\relation;
 
-use const phln\fn\nil;
 use const phln\object\values;
 use function phln\fn\compose;
 use function phln\fn\curryN;
@@ -22,7 +21,7 @@ const 𝑓difference = '\\phln\\relation\\𝑓difference';
  * @example
  *      \phln\relation\difference([1, 2, 3, 4], [3, 4, 5, 6]); // [1, 2]
  */
-function difference($a = nil, $b = nil)
+function difference($a = null, $b = null)
 {
     return curryN(2, 𝑓difference, [$a, $b]);
 }

--- a/src/relation/difference.php
+++ b/src/relation/difference.php
@@ -15,18 +15,18 @@ const 𝑓difference = '\\phln\\relation\\𝑓difference';
  *
  * @phlnSignature [*] -> [*] -> [*]
  * @phlnCategory relation
- * @param string|array $a
- * @param string|array $b
+ * @param array $left
+ * @param array $right
  * @return \Closure|array
  * @example
  *      \phln\relation\difference([1, 2, 3, 4], [3, 4, 5, 6]); // [1, 2]
  */
-function difference($a = null, $b = null)
+function difference(array $left = null, array $right = null)
 {
-    return curryN(2, 𝑓difference, [$a, $b]);
+    return curryN(2, 𝑓difference, func_get_args());
 }
 
-function 𝑓difference(array $a, array $b): array
+function 𝑓difference(array $left, array $right): array
 {
-    return compose([values, '\\array_diff'])($a, $b);
+    return compose([values, '\\array_diff'])($left, $right);
 }

--- a/src/relation/equals.php
+++ b/src/relation/equals.php
@@ -23,7 +23,7 @@ const 𝑓equals = '\\phln\\relation\\𝑓equals';
  */
 function equals($a = null, $b = null)
 {
-    return curryN(2, 𝑓equals, [$a, $b]);
+    return curryN(2, 𝑓equals, func_get_args());
 }
 
 function 𝑓equals($a, $b): bool

--- a/src/relation/equals.php
+++ b/src/relation/equals.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\relation;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const equals = '\\phln\\relation\\equals';
@@ -22,7 +21,7 @@ const 𝑓equals = '\\phln\\relation\\𝑓equals';
  *      \phln\relation\equals(1, '1'); // false
  *      \phln\relation\equals(1, 2); // false
  */
-function equals($a = nil, $b = nil)
+function equals($a = null, $b = null)
 {
     return curryN(2, 𝑓equals, [$a, $b]);
 }

--- a/src/relation/gt.php
+++ b/src/relation/gt.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\relation;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const gt = '\\phln\\relation\\gt';
@@ -20,7 +19,7 @@ const 𝑓gt = '\\phln\\relation\\𝑓gt';
  * @example
  *      \phln\relation\gt(2, 1); // true
  */
-function gt($a = nil, $b = nil)
+function gt($a = null, $b = null)
 {
     return curryN(2, 𝑓gt, [$a, $b]);
 }

--- a/src/relation/gt.php
+++ b/src/relation/gt.php
@@ -21,7 +21,7 @@ const 𝑓gt = '\\phln\\relation\\𝑓gt';
  */
 function gt($a = null, $b = null)
 {
-    return curryN(2, 𝑓gt, [$a, $b]);
+    return curryN(2, 𝑓gt, func_get_args());
 }
 
 function 𝑓gt($a, $b): bool

--- a/src/relation/gte.php
+++ b/src/relation/gte.php
@@ -23,7 +23,7 @@ const 𝑓gte = '\\phln\\relation\\𝑓gte';
  */
 function gte($a = null, $b = null)
 {
-    return curryN(2, 𝑓gte, [$a, $b]);
+    return curryN(2, 𝑓gte, func_get_args());
 }
 
 function 𝑓gte($a, $b): bool

--- a/src/relation/gte.php
+++ b/src/relation/gte.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\relation;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const gte = '\\phln\\relation\\gte';
@@ -22,7 +21,7 @@ const 𝑓gte = '\\phln\\relation\\𝑓gte';
  *      \phln\relation\gte(2, 2); // true
  *      \phln\relation\gte(2, 3); // false
  */
-function gte($a = nil, $b = nil)
+function gte($a = null, $b = null)
 {
     return curryN(2, 𝑓gte, [$a, $b]);
 }

--- a/src/relation/intersection.php
+++ b/src/relation/intersection.php
@@ -15,18 +15,18 @@ const 𝑓intersection = '\\phln\\relation\\𝑓intersection';
  *
  * @phlnSignature [*] -> [*] -> [*]
  * @phlnCategory relation
- * @param string $a
- * @param string $b
+ * @param array $left
+ * @param array $right
  * @return \Closure|mixed
  * @example
  *      \phln\relation\intersection([1, 2, 3, 4], [6, 4, 5]); // [4]
  */
-function intersection($a = null, $b = null)
+function intersection(array $left = [], array $right = [])
 {
-    return curryN(2, 𝑓intersection, [$a, $b]);
+    return curryN(2, 𝑓intersection, func_get_args());
 }
 
-function 𝑓intersection(array $a, array $b): array
+function 𝑓intersection(array $left, array $right): array
 {
-    return compose([values, '\\array_intersect'])($a, $b);
+    return compose([values, '\\array_intersect'])($left, $right);
 }

--- a/src/relation/intersection.php
+++ b/src/relation/intersection.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\relation;
 
-use const phln\fn\nil;
 use const phln\object\values;
 use function phln\fn\compose;
 use function phln\fn\curryN;
@@ -22,7 +21,7 @@ const 𝑓intersection = '\\phln\\relation\\𝑓intersection';
  * @example
  *      \phln\relation\intersection([1, 2, 3, 4], [6, 4, 5]); // [4]
  */
-function intersection($a = nil, $b = nil)
+function intersection($a = null, $b = null)
 {
     return curryN(2, 𝑓intersection, [$a, $b]);
 }

--- a/src/relation/lt.php
+++ b/src/relation/lt.php
@@ -13,20 +13,20 @@ const 𝑓lt = '\\phln\\relation\\𝑓lt';
  *
  * @phlnSignature Ord a => a -> a -> Boolean
  * @phlnCategory relation
- * @param mixed $a
- * @param mixed $b
+ * @param mixed $left
+ * @param mixed $right
  * @return \Closure|bool
  * @example
  *      \phln\relation\lt(1, 2); // true
  *      \phln\relation\lt(3, 2); // false
  *      \phln\relation\lt(2, 2); // false
  */
-function lt($a = null, $b = null)
+function lt($left = null, $right = null)
 {
-    return curryN(2, 𝑓lt, [$a, $b]);
+    return curryN(2, 𝑓lt, func_get_args());
 }
 
-function 𝑓lt($a, $b): bool
+function 𝑓lt($left, $right): bool
 {
-    return $a < $b;
+    return $left < $right;
 }

--- a/src/relation/lt.php
+++ b/src/relation/lt.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\relation;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const lt = '\\phln\\relation\\lt';
@@ -22,7 +21,7 @@ const 𝑓lt = '\\phln\\relation\\𝑓lt';
  *      \phln\relation\lt(3, 2); // false
  *      \phln\relation\lt(2, 2); // false
  */
-function lt($a = nil, $b = nil)
+function lt($a = null, $b = null)
 {
     return curryN(2, 𝑓lt, [$a, $b]);
 }

--- a/src/relation/lte.php
+++ b/src/relation/lte.php
@@ -13,18 +13,18 @@ const 𝑓lte = '\\phln\\relation\\𝑓lte';
  *
  * @phlnSignature Ord a => a -> a -> Boolean
  * @phlnCategory relation
- * @param string $a
- * @param string $b
+ * @param mixed $left
+ * @param mixed $right
  * @return \Closure|mixed
  * @example
  *      \phln\relation\lte(1, 2); // true
  */
-function lte($a = null, $b = null)
+function lte($left = null, $right = null)
 {
-    return curryN(2, 𝑓lte, [$a, $b]);
+    return curryN(2, 𝑓lte, func_get_args());
 }
 
-function 𝑓lte($a, $b): bool
+function 𝑓lte($left, $right): bool
 {
-    return $a <= $b;
+    return $left <= $right;
 }

--- a/src/relation/lte.php
+++ b/src/relation/lte.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\relation;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const lte = '\\phln\\relation\\lte';
@@ -20,7 +19,7 @@ const 𝑓lte = '\\phln\\relation\\𝑓lte';
  * @example
  *      \phln\relation\lte(1, 2); // true
  */
-function lte($a = nil, $b = nil)
+function lte($a = null, $b = null)
 {
     return curryN(2, 𝑓lte, [$a, $b]);
 }

--- a/src/relation/max.php
+++ b/src/relation/max.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\relation;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const max = '\\phln\\relation\\max';
@@ -17,7 +16,7 @@ const max = '\\phln\\relation\\max';
  * @param string $right
  * @return \Closure|mixed
  */
-function max($left = nil, $right = nil)
+function max($left = null, $right = null)
 {
     return curryN(2, '\\max', [$left, $right]);
 }

--- a/src/relation/max.php
+++ b/src/relation/max.php
@@ -12,11 +12,11 @@ const max = '\\phln\\relation\\max';
  *
  * @phlnSignature a -> a -> a
  * @phlnCategory relation
- * @param string $left
- * @param string $right
+ * @param mixed $left
+ * @param mixed $right
  * @return \Closure|mixed
  */
 function max($left = null, $right = null)
 {
-    return curryN(2, '\\max', [$left, $right]);
+    return curryN(2, '\\max', func_get_args());
 }

--- a/src/relation/min.php
+++ b/src/relation/min.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\relation;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const min = '\\phln\\relation\\min';
@@ -20,7 +19,7 @@ const 𝑓min = '\\phln\\relation\\𝑓min';
  * @example
  *      \phln\relation\min(1, -1); // -1
  */
-function min($left = nil, $right = nil)
+function min($left = null, $right = null)
 {
     return curryN(2, 𝑓min, [$left, $right]);
 }

--- a/src/relation/min.php
+++ b/src/relation/min.php
@@ -13,15 +13,15 @@ const 𝑓min = '\\phln\\relation\\𝑓min';
  *
  * @phlnSignature a -> a -> a
  * @phlnCategory relation
- * @param string $left
- * @param string $right
+ * @param mixed $left
+ * @param mixed $right
  * @return \Closure|mixed
  * @example
  *      \phln\relation\min(1, -1); // -1
  */
 function min($left = null, $right = null)
 {
-    return curryN(2, 𝑓min, [$left, $right]);
+    return curryN(2, 𝑓min, func_get_args());
 }
 
 function 𝑓min($left, $right)

--- a/src/relation/pathEq.php
+++ b/src/relation/pathEq.php
@@ -23,7 +23,7 @@ const 𝑓pathEq = '\\phln\\relation\\𝑓pathEq';
  * @example
  *      \phln\relation\pathEq('foo.bar', 1, ['foo' => ['bar' => 1]]); // true
  */
-function pathEq($path = nil, $value = nil, $object = nil)
+function pathEq($path = null, $value = null, $object = null)
 {
     return curryN(3, 𝑓pathEq, [$path, $value, $object]);
 }

--- a/src/relation/pathEq.php
+++ b/src/relation/pathEq.php
@@ -18,14 +18,14 @@ const 𝑓pathEq = '\\phln\\relation\\𝑓pathEq';
  * @phlnCategory relation
  * @param string $path
  * @param mixed $value
- * @param string|array $object
+ * @param array $object
  * @return \Closure|bool
  * @example
  *      \phln\relation\pathEq('foo.bar', 1, ['foo' => ['bar' => 1]]); // true
  */
-function pathEq($path = null, $value = null, $object = null)
+function pathEq(string $path = '', $value = null, array $object = [])
 {
-    return curryN(3, 𝑓pathEq, [$path, $value, $object]);
+    return curryN(3, 𝑓pathEq, func_get_args());
 }
 
 function 𝑓pathEq(string $path, $value, array $object): bool

--- a/src/relation/propEq.php
+++ b/src/relation/propEq.php
@@ -17,18 +17,18 @@ const 𝑓propEq = '\\phln\\relation\\𝑓propEq';
  * @phlnSignature k -> a -> {k: a} -> Boolean
  * @phlnCategory relation
  * @param string $prop
- * @param string $value
- * @param string $object
+ * @param mixed $value
+ * @param array $object
  * @return \Closure|mixed
  * @example
  *      \phln\relation\propEq('name', 'Jon', ['name' => 'Jon']); // true
  */
-function propEq($prop = null, $value = null, $object = null)
+function propEq(string $prop = '', $value = null, array $object = null)
 {
-    return curryN(3, 𝑓propEq, [$prop, $value, $object]);
+    return curryN(3, 𝑓propEq, func_get_args());
 }
 
-function 𝑓propEq($prop, $value, array $object): bool
+function 𝑓propEq(string $prop, $value, array $object): bool
 {
     $f = pipe([
         prop($prop),

--- a/src/relation/propEq.php
+++ b/src/relation/propEq.php
@@ -23,7 +23,7 @@ const 𝑓propEq = '\\phln\\relation\\𝑓propEq';
  * @example
  *      \phln\relation\propEq('name', 'Jon', ['name' => 'Jon']); // true
  */
-function propEq($prop = nil, $value = nil, $object = nil)
+function propEq($prop = null, $value = null, $object = null)
 {
     return curryN(3, 𝑓propEq, [$prop, $value, $object]);
 }

--- a/src/string/match.php
+++ b/src/string/match.php
@@ -24,9 +24,9 @@ const 𝑓match = '\\phln\\string\\𝑓match';
  *      \phln\string\match('/([a-z](o))/i', 'Lorem ipsum dolor'); // 'Lo'
  *      \phln\string\match('/([a-z](o))/ig', 'Lorem ipsum dolor'); // ['Lo', 'do', 'lo']
  */
-function match($regexp = null, $test = null)
+function match($regexp = null, string $test = '')
 {
-    return curryN(2, 𝑓match, [$regexp, $test]);
+    return curryN(2, 𝑓match, func_get_args());
 }
 
 function 𝑓match($regexp, string $test)

--- a/src/string/match.php
+++ b/src/string/match.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace phln\string;
 
 use phln\RegExp;
-use const phln\fn\nil;
 use function phln\collection\head;
 use function phln\fn\curryN;
 use function phln\type\𝑓is;
@@ -25,7 +24,7 @@ const 𝑓match = '\\phln\\string\\𝑓match';
  *      \phln\string\match('/([a-z](o))/i', 'Lorem ipsum dolor'); // 'Lo'
  *      \phln\string\match('/([a-z](o))/ig', 'Lorem ipsum dolor'); // ['Lo', 'do', 'lo']
  */
-function match($regexp = nil, $test = nil)
+function match($regexp = null, $test = null)
 {
     return curryN(2, 𝑓match, [$regexp, $test]);
 }

--- a/src/string/replace.php
+++ b/src/string/replace.php
@@ -27,7 +27,7 @@ const 𝑓replace = '\\phln\\string\\𝑓replace';
  *      \phln\string\replace('/foo/', 'bar', 'foo foo foo'); // 'bar foo foo'
  *      \phln\string\replace('/foo/g', 'bar', 'foo foo foo'); // 'bar bar bar'
  */
-function replace($regexp = nil, $replacement = nil, $text = nil)
+function replace($regexp = null, $replacement = null, $text = null)
 {
     return curryN(3, 𝑓replace, [$regexp, $replacement, $text]);
 }

--- a/src/string/replace.php
+++ b/src/string/replace.php
@@ -19,7 +19,7 @@ const 𝑓replace = '\\phln\\string\\𝑓replace';
  *
  * @phlnSignature RegExp -> String -> String -> String
  * @phlnCategory string
- * @param string $regexp
+ * @param string|RegExp $regexp
  * @param string $replacement
  * @param string $text
  * @return \Closure|string
@@ -27,9 +27,9 @@ const 𝑓replace = '\\phln\\string\\𝑓replace';
  *      \phln\string\replace('/foo/', 'bar', 'foo foo foo'); // 'bar foo foo'
  *      \phln\string\replace('/foo/g', 'bar', 'foo foo foo'); // 'bar bar bar'
  */
-function replace($regexp = null, $replacement = null, $text = null)
+function replace($regexp = null, string $replacement = '', string $text = '')
 {
-    return curryN(3, 𝑓replace, [$regexp, $replacement, $text]);
+    return curryN(3, 𝑓replace, func_get_args());
 }
 
 function 𝑓replace($regexp, string $replacement, string $text): string

--- a/src/string/split.php
+++ b/src/string/split.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace phln\string;
 
 use phln\RegExp;
-use const phln\fn\nil;
 use function phln\fn\curryN;
 use function phln\type\𝑓is;
 
@@ -25,7 +24,7 @@ const 𝑓split = '\\phln\\string\\𝑓split';
  * @example
  *      \phln\string\split('/', 'a/b'); // ['a', 'b']
  */
-function split($delimiter = nil, $text = nil)
+function split($delimiter = null, $text = null)
 {
     return curryN(2, 𝑓split, [$delimiter, $text]);
 }

--- a/src/string/split.php
+++ b/src/string/split.php
@@ -18,15 +18,15 @@ const 𝑓split = '\\phln\\string\\𝑓split';
  * @phlnSignature String -> String -> [String]
  * @phlnSignature RegExp -> String -> [String]
  * @phlnCategory string
- * @param string $delimiter
+ * @param string|RegExp $delimiter
  * @param string $text
  * @return \Closure|array
  * @example
  *      \phln\string\split('/', 'a/b'); // ['a', 'b']
  */
-function split($delimiter = null, $text = null)
+function split($delimiter = null, string $text = '')
 {
-    return curryN(2, 𝑓split, [$delimiter, $text]);
+    return curryN(2, 𝑓split, func_get_args());
 }
 
 function 𝑓split($delimiter, string $text): array

--- a/src/type/is.php
+++ b/src/type/is.php
@@ -28,9 +28,9 @@ const 𝑓is = '\\phln\\type\\𝑓is';
  *      \phln\type\is(\stdClass::class, new \stdClass); // true
  *      \phln\type\is(float, 1.1); // true
  */
-function is($type = null, $value = null)
+function is(string $type = '', $value = null)
 {
-    return curryN(2, 𝑓is, [$type, $value]);
+    return curryN(2, 𝑓is, func_get_args());
 }
 
 function 𝑓is(string $type, $value): bool

--- a/src/type/is.php
+++ b/src/type/is.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace phln\type;
 
-use const phln\fn\nil;
 use function phln\fn\curryN;
 
 const is = '\\phln\\type\\is';
@@ -29,7 +28,7 @@ const 𝑓is = '\\phln\\type\\𝑓is';
  *      \phln\type\is(\stdClass::class, new \stdClass); // true
  *      \phln\type\is(float, 1.1); // true
  */
-function is($type = nil, $value = nil)
+function is($type = null, $value = null)
 {
     return curryN(2, 𝑓is, [$type, $value]);
 }

--- a/tests/fn/CurryNTest.php
+++ b/tests/fn/CurryNTest.php
@@ -38,19 +38,6 @@ class CurryNTest extends \Phln\Build\PhpUnit\TestCase
     }
 
     /** @test */
-    function it_filters_out_null_arguments()
-    {
-        $sum = function ($a, $b, $c) {
-            return $a + $b + $c;
-        };
-
-        $expected = $sum(1, 2, 3);
-        $g = $this->callFn(3, $sum, [null, null, 1]);
-
-        $this->assertEquals($expected, $g(2, 3));
-    }
-
-    /** @test */
     function it_curries_until_n_is_matched()
     {
         $sum = function (... $args) {

--- a/tests/fn/CurryNTest.php
+++ b/tests/fn/CurryNTest.php
@@ -38,14 +38,14 @@ class CurryNTest extends \Phln\Build\PhpUnit\TestCase
     }
 
     /** @test */
-    function it_filters_out_nil_arguments()
+    function it_filters_out_null_arguments()
     {
         $sum = function ($a, $b, $c) {
             return $a + $b + $c;
         };
 
         $expected = $sum(1, 2, 3);
-        $g = $this->callFn(3, $sum, [\phln\fn\nil, \phln\fn\nil, 1]);
+        $g = $this->callFn(3, $sum, [null, null, 1]);
 
         $this->assertEquals($expected, $g(2, 3));
     }

--- a/tests/fn/CurryTest.php
+++ b/tests/fn/CurryTest.php
@@ -38,14 +38,14 @@ class CurryTest extends \Phln\Build\PhpUnit\TestCase
     }
 
     /** @test */
-    function it_filters_out_nil_arguments()
+    function it_filters_out_null_arguments()
     {
         $sum = function ($a, $b, $c) {
             return $a + $b + $c;
         };
 
         $expected = $sum(1, 2, 3);
-        $g = $this->callFn($sum, [\phln\fn\nil, \phln\fn\nil, 1]);
+        $g = $this->callFn($sum, [null, null, 1]);
 
         $this->assertEquals($expected, $g(2, 3));
     }

--- a/tests/fn/CurryTest.php
+++ b/tests/fn/CurryTest.php
@@ -36,17 +36,4 @@ class CurryTest extends \Phln\Build\PhpUnit\TestCase
 
         $this->assertEquals($expected, $g);
     }
-
-    /** @test */
-    function it_filters_out_null_arguments()
-    {
-        $sum = function ($a, $b, $c) {
-            return $a + $b + $c;
-        };
-
-        $expected = $sum(1, 2, 3);
-        $g = $this->callFn($sum, [null, null, 1]);
-
-        $this->assertEquals($expected, $g(2, 3));
-    }
 }


### PR DESCRIPTION
This PR removes `nil` const. Also `curry`/`curryN` functions will not perform initial arguments filtering.

Closes #19